### PR TITLE
Add missing @types/express to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         ]
     },
     "devDependencies": {
+        "@types/express": "^4.17.6",
         "@types/jest": "^24.0.18",
         "@types/node": "^10.10.1",
         "@types/request-promise-native": "^1.0.17",


### PR DESCRIPTION
reference to `express` has been included to n8n-workflow/dist/src/Interfaces.d.ts:2:26 so `npm run build` is failing.