### PR TITLE
Adjust `documentationUrl` rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
 			extends: ['plugin:n8n-nodes-base/credentials'],
 			rules: {
 				'n8n-nodes-base/cred-class-field-documentation-url-missing': 'off',
+				'n8n-nodes-base/cred-class-field-documentation-url-miscased': 'off',
 			},
 		},
 		{

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/express": "^4.17.6",
     "@types/request-promise-native": "~1.0.15",
     "@typescript-eslint/parser": "^5.29.0",
-    "eslint-plugin-n8n-nodes-base": "^1.2.0",
+    "eslint-plugin-n8n-nodes-base": "^1.4.1",
     "gulp": "^4.0.2",
     "n8n-core": "^0.125.0",
     "n8n-workflow": "^0.107.0",


### PR DESCRIPTION
The two old rules `cred-class-field-documentation-url-missing` and `cred-class-field-documentation-url-miscased` are now disabled for community rules (but kept enabled for main repo nodes) and the new rule [`cred-class-field-documentation-url-not-http-url`](https://github.com/ivov/eslint-plugin-n8n-nodes-base/blob/master/docs/rules/cred-class-field-documentation-url-not-http-url.md) is implicitly enabled only for community nodes, meaning that `documentationUrl` is optional for community nodes but, if present, must be an HTTP URL, defined as any string passing the [`URL` constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL).