### PR TITLE
Disable pairing lintings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,8 @@ module.exports = {
 				'n8n-nodes-base/node-execute-block-missing-continue-on-fail': 'off',
 				'n8n-nodes-base/node-resource-description-filename-against-convention': 'off',
 				'n8n-nodes-base/node-param-fixed-collection-type-unsorted-items': 'off',
+				'n8n-nodes-base/node-execute-block-operation-missing-singular-pairing': 'off',
+				'n8n-nodes-base/node-execute-block-operation-missing-plural-pairing': 'off',
 			},
 		},
 	],


### PR DESCRIPTION
@krynble For context, I discussed this with Jan today and we are planning to abstract away the additions of the pairing autofixes into the node's request functions, so disabling the pairing rules until the autofixes are updated.

https://github.com/ivov/eslint-plugin-n8n-nodes-base/blob/master/docs/rules/node-execute-block-operation-missing-plural-pairing.md

https://github.com/ivov/eslint-plugin-n8n-nodes-base/blob/master/docs/rules/node-execute-block-operation-missing-singular-pairing.md