### PR TITLE
modernize ts options

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     ]
   },
   "devDependencies": {
+    "@types/node": "^20.14.11",
     "@typescript-eslint/parser": "^7.15.0",
     "eslint": "^8.56.0",
     "eslint-plugin-n8n-nodes-base": "^1.16.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"strict": true,
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"module": "preserve",
 		"target": "es2019",
 		"lib": ["es2019", "es2020", "es2022.error"],
+		"types": ["node"],
 		"removeComments": true,
 		"useUnknownInCatchVariables": false,
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
1. The `node` moduleResolution option has been deprecated for a while
2. A good default set of tsconfig options are explained here: https://www.totaltypescript.com/tsconfig-cheat-sheet