### PR TITLE
Add n8n-nodes-execute-code

### DIFF
--- a/community-nodes.json
+++ b/community-nodes.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "n8n-nodes-execute-code",
+    "version": "0.1.4",
+    "author": "tuananhit1612",
+    "description": "Execute programming code submissions using Judge0 API.",
+    "link": "https://www.npmjs.com/package/n8n-nodes-execute-code"
+  }
+]

--- a/community-nodes.json
+++ b/community-nodes.json
@@ -1,9 +1,9 @@
 [
   {
-    "name": "n8n-nodes-execute-code",
+    "name": "n8n-nodes-clean-data",
     "version": "0.1.4",
-    "author": "tuananhit1612",
-    "description": "Execute programming code submissions using Judge0 API.",
+    "author": "HutechFoss",
+    "description": "A custom n8n node to clean and preprocess data using Recursive Feature Elimination (RFE) powered by Python.",
     "link": "https://www.npmjs.com/package/n8n-nodes-execute-code"
   }
 ]


### PR DESCRIPTION
This PR adds the `n8n-nodes-execute-code` package to the community nodes JSON file. This package allows users to execute programming code submissions using the Judge0 API.
