### PR TITLE
Add rimraf to build to help prevent examples being published

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "tsc && gulp build:icons",
+    "build": "npx rimraf dist && tsc && gulp build:icons",
     "dev": "tsc --watch",
     "format": "prettier nodes credentials --write",
     "lint": "eslint nodes credentials package.json",


### PR DESCRIPTION
While vetting new community nodes we have seen a lot of cases where the example nodes and credentials are published, Likely due to users building the example then working away and doing a build and publish after removing the code.

This PR uses `rimraf` to delete the dist folder when build is called to try and prevent this.