### PR TITLE
Small tweaks to README and updated icon example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ This repo contains example nodes to help you get started building your own custo
 
 To make your custom node available to the community, you must create it as an npm package, and [submit it to the npm registry](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry).
 
+If you would like your node to be available on n8n cloud you can also [submit your node for verification](https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/).
+
 ## Prerequisites
 
 You need the following installed on your development machine:
 
 * [git](https://git-scm.com/downloads)
-* Node.js and pnpm. Minimum version Node 20. You can find instructions on how to install both using nvm (Node Version Manager) for Linux, Mac, and WSL [here](https://github.com/nvm-sh/nvm). For Windows users, refer to Microsoft's guide to [Install NodeJS on Windows](https://docs.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-windows).
+* Node.js and npm. Minimum version Node 20. You can find instructions on how to install both using nvm (Node Version Manager) for Linux, Mac, and WSL [here](https://github.com/nvm-sh/nvm). For Windows users, refer to Microsoft's guide to [Install NodeJS on Windows](https://docs.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-windows).
 * Install n8n with:
   ```
   npm install n8n -g

--- a/nodes/HttpBin/HttpBin.node.ts
+++ b/nodes/HttpBin/HttpBin.node.ts
@@ -5,7 +5,7 @@ export class HttpBin implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'HttpBin',
 		name: 'httpBin',
-		icon: 'file:httpbin.svg',
+		icon: { light: 'file:httpbin.svg', dark: 'file:httpbin.svg' },
 		group: ['transform'],
 		version: 1,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
@@ -15,6 +15,7 @@ export class HttpBin implements INodeType {
 		},
 		inputs: [NodeConnectionType.Main],
 		outputs: [NodeConnectionType.Main],
+		usableAsTool: true,
 		credentials: [
 			{
 				name: 'httpbinApi',


### PR DESCRIPTION
This PR updates `httpBin` example to also set `usableAsTool`, It also updates the `icon` to show how to support both `dark` and `light` options.

The readme has also been updated to include a line about submitting a node for verification.