### PR TITLE
Remove package.json from ESLint target

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "build": "npx rimraf dist && tsc && gulp build:icons",
     "dev": "tsc --watch",
     "format": "prettier nodes credentials --write",
-    "lint": "eslint nodes credentials package.json",
-    "lintfix": "eslint nodes credentials package.json --fix",
-    "prepublishOnly": "npm build && npm lint -c .eslintrc.prepublish.js nodes credentials package.json"
+    "lint": "eslint nodes credentials",
+    "lintfix": "eslint nodes credentials --fix",
+    "prepublishOnly": "npm build && npm lint -c .eslintrc.prepublish.js nodes credentials"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## 📝 Description  

This PR removes `package.json` from the list of files linted by ESLint.

Since `package.json` is a JSON configuration file—not JavaScript code—linting it with ESLint is non-standard and does not provide meaningful value. Dedicated tools such as [`npm-package-json-lint`](https://www.npmjs.com/package/npm-package-json-lint) or [`sort-package-json`](https://github.com/keithamus/sort-package-json) are more appropriate for formatting and validating `package.json`.

### Changes:
- Removed `package.json` from the `lint` and `lintfix` npm scripts
- Updated `prepublishOnly` script to exclude `package.json`

### Motivation:
ESLint is designed for analyzing JavaScript/TypeScript source files. Including `package.json` could lead to confusion or unnecessary errors. This cleanup improves the clarity and accuracy of the linting process.