### PR TITLE
Add rimraf dependency to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-n8n-nodes-base": "^1.16.3",
     "gulp": "^5.0.0",
     "prettier": "^3.5.3",
+    "rimraf": "^6.0.1",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Adds the rimraf package to the dev dependencies in order to fix the `npm run build` script.