### PR TITLE
Fix: continueOnFail error management

### DIFF
--- a/nodes/ExampleNode/ExampleNode.node.ts
+++ b/nodes/ExampleNode/ExampleNode.node.ts
@@ -39,6 +39,7 @@ export class ExampleNode implements INodeType {
 	// You can make async calls and use `await`.
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
+		const itemCount = items.length;
 
 		let item: INodeExecutionData;
 		let myString: string;
@@ -46,7 +47,7 @@ export class ExampleNode implements INodeType {
 		// Iterates over all input items and add the key "myString" with the
 		// value the parameter "myString" resolves to.
 		// (This could be a different value for each item in case it contains an expression)
-		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+		for (let itemIndex = 0; itemIndex < itemCount; itemIndex++) {
 			try {
 				myString = this.getNodeParameter('myString', itemIndex, '') as string;
 				item = items[itemIndex];
@@ -56,7 +57,7 @@ export class ExampleNode implements INodeType {
 				// This node should never fail but we want to showcase how
 				// to handle errors.
 				if (this.continueOnFail()) {
-					items.push({ json: this.getInputData(itemIndex)[0].json, error, pairedItem: itemIndex });
+					items[itemIndex].error = error;
 				} else {
 					// Adding `itemIndex` allows other workflows to handle this error
 					if (error.context) {


### PR DESCRIPTION
I observed some weird behaviors when testing a custom node which was used with `continueOnFail()`, and would return the items, as is done in this example.

## Issues:

- Records are being pushed in the `items` array within a loop over them, this essentially causes an _**infinite loop**_. I fixed that loop by adding `itemCount` 
- Upon fixing the infinite loop, I noticed both `success` and `error` branches of the node would activate, that was because the pushed item had an `error` field (which triggers the error branch), but the original item was still present without an error field (which trigger the success branch)

I've managed to get a proper working behaviour with this change. There may be better fixes to this, but this approach worked for me.