### PR TITLE
fix: correct NodeConnectionType import to NodeConnectionTypes

### DIFF
--- a/nodes/ExampleNode/ExampleNode.node.ts
+++ b/nodes/ExampleNode/ExampleNode.node.ts
@@ -4,7 +4,7 @@ import type {
 	INodeType,
 	INodeTypeDescription,
 } from 'n8n-workflow';
-import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 export class ExampleNode implements INodeType {
 	description: INodeTypeDescription = {
@@ -16,8 +16,8 @@ export class ExampleNode implements INodeType {
 		defaults: {
 			name: 'Example Node',
 		},
-		inputs: [NodeConnectionType.Main],
-		outputs: [NodeConnectionType.Main],
+		inputs: [NodeConnectionTypes.Main],
+		outputs: [NodeConnectionTypes.Main],
 		usableAsTool: true,
 		properties: [
 			// Node properties which the user gets displayed and

--- a/nodes/HttpBin/HttpBin.node.ts
+++ b/nodes/HttpBin/HttpBin.node.ts
@@ -1,4 +1,4 @@
-import { INodeType, INodeTypeDescription, NodeConnectionType } from 'n8n-workflow';
+import { INodeType, INodeTypeDescription, NodeConnectionTypes } from 'n8n-workflow';
 import { httpVerbFields, httpVerbOperations } from './HttpVerbDescription';
 
 export class HttpBin implements INodeType {
@@ -13,8 +13,8 @@ export class HttpBin implements INodeType {
 		defaults: {
 			name: 'HttpBin',
 		},
-		inputs: [NodeConnectionType.Main],
-		outputs: [NodeConnectionType.Main],
+		inputs: [NodeConnectionTypes.Main],
+		outputs: [NodeConnectionTypes.Main],
 		usableAsTool: true,
 		credentials: [
 			{


### PR DESCRIPTION
## Summary
  - Fixed TypeScript error where `NodeConnectionType` (a type) was being imported
  instead of `NodeConnectionTypes` (the actual constant)
  - Updated both `ExampleNode` and `HttpBin` nodes to use the correct import

  ## Problem
  The nodes were trying to use `NodeConnectionType.Main` which caused the
  TypeScript error:
  - `'NodeConnectionType' only refers to a type, but is being used as a value here`

  ## Solution
  Changed the import from `NodeConnectionType` to `NodeConnectionTypes` (with an
  's') which is the actual exported constant from n8n-workflow.

  ## Files changed
  - `nodes/ExampleNode/ExampleNode.node.ts`
  - `nodes/HttpBin/HttpBin.node.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace NodeConnectionType with NodeConnectionTypes and update inputs/outputs in both nodes.
> 
> - **Nodes**:
>   - `nodes/ExampleNode/ExampleNode.node.ts` and `nodes/HttpBin/HttpBin.node.ts`:
>     - Switch import `NodeConnectionType` -> `NodeConnectionTypes`.
>     - Update `inputs`/`outputs` to use `NodeConnectionTypes.Main`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e709b15287a41392b2bddd3dc6a6d60c67982f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->