### PR TITLE
feat: add automated npm publish workflow with provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
 
+# Cancel in-progress runs for the same branch/PR to avoid wasting CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,16 +18,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: 'lts/*'
+          cache: 'npm'
 
       - name: Install dependencies
-        run: 'npm ci'
+        run: npm ci
 
       - name: Run lint
-        run: 'npm run lint'
+        run: npm run lint
 
       - name: Run build
-        run: 'npm run build'
+        run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,103 @@
+# Publishes this n8n community node package to npm on every version tag push.
+#
+# Starting May 1 2026, n8n requires all community nodes to be published via
+# GitHub Actions with npm provenance statements. This workflow satisfies that
+# requirement. Provenance lets anyone cryptographically verify that a package
+# was built by this exact workflow, from this exact repository and commit.
+#
+# ─── PREREQUISITES ─────────────────────────────────────────────────────────────
+#
+# @n8n/node-cli ≥ 0.23.0 is required. Earlier versions do not support the
+# provenance flag passed by `npm run release` in CI, and the publish step will
+# fail. Check the version installed in this project with:
+#
+#   npm list @n8n/node-cli
+#
+# To upgrade:
+#
+#   npm install --save-dev @n8n/node-cli@latest
+#
+# ─── ONE-TIME SETUP ────────────────────────────────────────────────────────────
+#
+# Option A — OIDC Trusted Publishing (recommended, no long-lived secrets):
+#   1. Log in to npmjs.com and open your package's settings.
+#   2. Under "Publish access" → "Trusted Publishers", click "Add a publisher".
+#   3. Select GitHub Actions and fill in:
+#        Repository owner: <your-github-username-or-org>
+#        Repository name:  <your-repo-name>
+#        Workflow name:    publish.yml
+#        Environment:      (leave blank unless you use GitHub Environments)
+#   4. Leave the NPM_TOKEN secret unset in this repository. GitHub's OIDC
+#      token is used instead — no secret ever touches your repo settings.
+#
+# Option B — npm Automation Token (fallback):
+#   1. On npmjs.com: Access Tokens → Generate New Token → Granular Access Token.
+#      Scope it to this package with "Read and write" publish permission.
+#   2. In GitHub: Settings → Secrets and variables → Actions → New secret.
+#      Name it NPM_TOKEN and paste the token value.
+#
+# Both options work with --provenance. Provenance is signed by GitHub's OIDC
+# infrastructure regardless of how npm authentication is handled.
+#
+# ─── TAG CONVENTION ────────────────────────────────────────────────────────────
+#
+# This workflow triggers on tags matching "*.*.*" (e.g. 0.2.0).
+# If you prefer tags with a "v" prefix (e.g. v0.2.0), change the filter to:
+#   tags: ['v*.*.*']
+#
+# ─── RELEASE PROCESS ───────────────────────────────────────────────────────────
+#
+# Run the following command locally to start an interactive release:
+#
+#   npm run release
+#
+# This will lint, build, prompt for a version bump, update the changelog,
+# commit, tag, and push — which triggers this workflow to publish to npm.
+
+name: Publish
+
+on:
+  push:
+    tags:
+      # Matches 0.1.0, 1.2.3, 2.0.0-rc.1, etc.
+      # See "TAG CONVENTION" above if you prefer tags with a "v" prefix.
+      - '*.*.*'
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to mint an OIDC token for npm provenance attestation.
+      id-token: write
+      # Scoped down from the default (write) for least-privilege publishing.
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          # registry-url is required for the NODE_AUTH_TOKEN / OIDC exchange.
+          registry-url: 'https://registry.npmjs.org/'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Release
+        # `npm run release` detects the GitHub Actions environment and publishes
+        # to npm with a provenance attestation (requires id-token: write above).
+        # Lint and build run automatically as part of the release process.
+        #
+        # NODE_AUTH_TOKEN   Works for both auth options:
+        #   Option A (OIDC): Leave NPM_TOKEN secret unset. setup-node writes
+        #                    an .npmrc using this variable; when it is empty,
+        #                    npm falls through to the OIDC exchange automatically.
+        #   Option B (token): Set NPM_TOKEN in repo secrets and it is used here.
+        run: npm run release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,23 +81,21 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-          # registry-url is required for the NODE_AUTH_TOKEN / OIDC exchange.
-          registry-url: 'https://registry.npmjs.org/'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
       - name: Release
-        # `npm run release` detects the GitHub Actions environment and publishes
-        # to npm with a provenance attestation (requires id-token: write above).
+        # Publishes to npm with a provenance attestation (requires id-token: write above).
         # Lint and build run automatically as part of the release process.
         #
-        # NODE_AUTH_TOKEN   Works for both auth options:
-        #   Option A (OIDC): Leave NPM_TOKEN secret unset. setup-node writes
-        #                    an .npmrc using this variable; when it is empty,
-        #                    npm falls through to the OIDC exchange automatically.
-        #   Option B (token): Set NPM_TOKEN in repo secrets and it is used here.
-        run: npm run release
+        # Option A (OIDC): leave NPM_TOKEN unset — the token step is skipped and
+        #   npm uses the OIDC exchange instead.
+        # Option B (token): set NPM_TOKEN in repo secrets — it is written to
+        #   .npmrc here before publishing.
+        run: |
+          [ -n "$NPM_TOKEN" ] && npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          npm run release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -170,13 +170,28 @@ Before publishing:
 
 ### 10. Publish to npm
 
-Publish your package to make it available to the n8n community:
+Publishing is handled automatically by the included GitHub Actions workflow ([.github/workflows/publish.yml](.github/workflows/publish.yml)). It runs on every version tag push and publishes to npm with a provenance attestation — a requirement for n8n community nodes starting May 1, 2026.
+
+#### One-time setup
+
+Configure npm to trust this repository's GitHub Actions workflow so it can publish on your behalf. Log in to [npmjs.com](https://npmjs.com), open your package settings, and under **Publish access → Trusted Publishers** add a publisher with:
+
+- **Repository owner**: your GitHub username or org
+- **Repository name**: your repo name
+- **Workflow name**: `publish.yml`
+
+No token or secret needs to be stored in GitHub — the workflow uses GitHub's OIDC token instead.
+
+> [!NOTE]
+> If you prefer a traditional npm token, create a Granular Access Token on npmjs.com and store it as `NPM_TOKEN` in your repository's Actions secrets. See the comments at the top of `.github/workflows/publish.yml` for details.
+
+#### Releasing a new version
 
 ```bash
-npm publish
+npm run release
 ```
 
-Learn more about [publishing to npm](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry).
+This lints, builds, prompts for a version bump, updates the changelog, commits, tags, and pushes — which triggers the workflow to publish to npm.
 
 ### 11. Submit for Verification (Optional)
 
@@ -201,14 +216,14 @@ Get your node verified for n8n Cloud:
 
 This starter includes several npm scripts to streamline development:
 
-| Script                | Description                                                      |
-| --------------------- | ---------------------------------------------------------------- |
-| `npm run dev`         | Start n8n with your node and watch for changes (runs `n8n-node dev`) |
-| `npm run build`       | Compile TypeScript to JavaScript for production (runs `n8n-node build`) |
-| `npm run build:watch` | Build in watch mode (auto-rebuild on changes)                    |
-| `npm run lint`        | Check your code for errors and style issues (runs `n8n-node lint`) |
+| Script                | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `npm run dev`         | Start n8n with your node and watch for changes (runs `n8n-node dev`)        |
+| `npm run build`       | Compile TypeScript to JavaScript for production (runs `n8n-node build`)     |
+| `npm run build:watch` | Build in watch mode (auto-rebuild on changes)                               |
+| `npm run lint`        | Check your code for errors and style issues (runs `n8n-node lint`)          |
 | `npm run lint:fix`    | Automatically fix linting issues when possible (runs `n8n-node lint --fix`) |
-| `npm run release`     | Create a new release (runs `n8n-node release`)                   |
+| `npm run release`     | Create a new release (runs `n8n-node release`)                              |
 
 > [!TIP]
 > These scripts use the [@n8n/node-cli](https://www.npmjs.com/package/@n8n/node-cli) under the hood. You can also run CLI commands directly, e.g., `npx n8n-node dev`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "*",
-				"eslint": "10.0.3",
+				"eslint": "9.39.4",
 				"prettier": "3.8.1",
-				"release-it": "^19.2.4",
+				"release-it": "19.2.4",
 				"typescript": "5.9.3"
 			},
 			"peerDependencies": {
@@ -198,44 +198,75 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.23.3",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-			"integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^3.0.3",
+				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
-				"minimatch": "^10.2.4"
+				"minimatch": "^3.1.5"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-			"integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.1"
+				"@eslint/core": "^0.17.0"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-			"integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -322,27 +353,27 @@
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-			"integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-			"integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.1",
+				"@eslint/core": "^0.17.0",
 				"levn": "^0.4.1"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@humanfs/core": {
@@ -1598,7 +1629,6 @@
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -1852,7 +1882,6 @@
 			"integrity": "sha512-kIUidOgc0ZdyXo4Ahn9Zas+OayqOfk4ZoKPi7XaDipNSWSApc2+QK5BVcjvwtzxstsNOrmXJiJWEN6WPF/MvAw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@cfworker/json-schema": "^4.0.2",
 				"ansi-styles": "^5.0.0",
@@ -2683,13 +2712,6 @@
 				"@types/ms": "*"
 			}
 		},
-		"node_modules/@types/esrecurse": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2956,7 +2978,6 @@
 			"integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
 				"@typescript-eslint/scope-manager": "8.57.1",
@@ -4439,31 +4460,33 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
-			"integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
-				"@eslint-community/regexpp": "^4.12.2",
-				"@eslint/config-array": "^0.23.3",
-				"@eslint/config-helpers": "^0.5.2",
-				"@eslint/core": "^1.1.1",
-				"@eslint/plugin-kit": "^0.6.1",
+				"@eslint-community/regexpp": "^4.12.1",
+				"@eslint/config-array": "^0.21.2",
+				"@eslint/config-helpers": "^0.4.2",
+				"@eslint/core": "^0.17.0",
+				"@eslint/eslintrc": "^3.3.5",
+				"@eslint/js": "9.39.4",
+				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
 				"ajv": "^6.14.0",
+				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^9.1.2",
-				"eslint-visitor-keys": "^5.0.1",
-				"espree": "^11.1.1",
-				"esquery": "^1.7.0",
+				"eslint-scope": "^8.4.0",
+				"eslint-visitor-keys": "^4.2.1",
+				"espree": "^10.4.0",
+				"esquery": "^1.5.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^8.0.0",
@@ -4473,7 +4496,8 @@
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"minimatch": "^10.2.4",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.1.5",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -4481,7 +4505,7 @@
 				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://eslint.org/donate"
@@ -4968,19 +4992,17 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@types/esrecurse": "^4.3.1",
-				"@types/estree": "^1.0.8",
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -4999,45 +5021,126 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+		"node_modules/eslint/node_modules/@eslint/eslintrc": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
 			"dev": true,
-			"license": "Apache-2.0",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^6.14.0",
+				"debug": "^4.3.2",
+				"espree": "^10.0.1",
+				"globals": "^14.0.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.1",
+				"minimatch": "^3.1.5",
+				"strip-json-comments": "^3.1.1"
+			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/@eslint/js": {
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			}
+		},
+		"node_modules/eslint/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/eslint/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/eslint/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/globals": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/espree": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.16.0",
+				"acorn": "^8.15.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^5.0.1"
+				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -6011,6 +6114,7 @@
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -9348,7 +9452,6 @@
 			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,93 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "*",
-				"eslint": "9.32.0",
-				"prettier": "3.6.2",
-				"release-it": "^19.0.4",
-				"typescript": "5.9.2"
+				"eslint": "10.0.3",
+				"prettier": "3.8.1",
+				"release-it": "^19.2.4",
+				"typescript": "5.9.3"
 			},
 			"peerDependencies": {
 				"n8n-workflow": "*"
 			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.27.3.tgz",
+			"integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^18.11.18",
+				"@types/node-fetch": "^2.6.4",
+				"abort-controller": "^3.0.0",
+				"agentkeepalive": "^4.2.1",
+				"form-data-encoder": "1.7.2",
+				"formdata-node": "^4.3.2",
+				"node-fetch": "^2.6.7"
+			}
+		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@browserbasehq/sdk": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.9.0.tgz",
+			"integrity": "sha512-Xzm1+6suzQypXjley4Phqer++pjnYyST6S7CArUn3kWyGA8aruXjAV5wkmqE21lgXo9K3/OQJvCu48bKEZFNDQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "^18.11.18",
+				"@types/node-fetch": "^2.6.4",
+				"abort-controller": "^3.0.0",
+				"agentkeepalive": "^4.2.1",
+				"form-data-encoder": "1.7.2",
+				"formdata-node": "^4.3.2",
+				"node-fetch": "^2.6.7"
+			}
+		},
+		"node_modules/@browserbasehq/stagehand": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@browserbasehq/stagehand/-/stagehand-1.14.0.tgz",
+			"integrity": "sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.27.3",
+				"@browserbasehq/sdk": "^2.0.0",
+				"ws": "^8.18.0",
+				"zod-to-json-schema": "^3.23.5"
+			},
+			"peerDependencies": {
+				"@playwright/test": "^1.42.1",
+				"deepmerge": "^4.3.1",
+				"dotenv": "^16.4.5",
+				"openai": "^4.62.1",
+				"zod": "^3.23.8"
+			}
+		},
+		"node_modules/@browserbasehq/stagehand/node_modules/zod-to-json-schema": {
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+			"integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25 || ^4"
+			}
+		},
+		"node_modules/@cfworker/json-schema": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@clack/core": {
 			"version": "0.5.0",
@@ -42,22 +121,35 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@emnapi/core": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
-			"integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+			"integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.1.0",
+				"@emnapi/wasi-threads": "1.2.0",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-			"integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+			"integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -66,9 +158,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+			"integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -77,9 +169,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-			"integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -96,9 +188,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-			"integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -106,78 +198,57 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-			"integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+			"version": "0.23.3",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+			"integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^2.1.6",
+				"@eslint/object-schema": "^3.0.3",
 				"debug": "^4.3.1",
-				"minimatch": "^3.1.2"
+				"minimatch": "^10.2.4"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/@eslint/config-array/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-			"integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+			"integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.1.1"
+			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+			"integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-			"integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^10.0.1",
-				"globals": "^14.0.0",
+				"espree": "^9.6.0",
+				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -185,11 +256,18 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
 			"version": "1.1.12",
@@ -202,10 +280,28 @@
 				"concat-map": "0.0.1"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/espree": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.9.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -216,40 +312,37 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.32.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
-			"integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://eslint.org/donate"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-			"integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+			"integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-			"integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+			"integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.15.2",
+				"@eslint/core": "^1.1.1",
 				"levn": "^0.4.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@humanfs/core": {
@@ -283,7 +376,6 @@
 			"deprecated": "Use @eslint/config-array instead",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^2.0.3",
 				"debug": "^4.3.1",
@@ -293,25 +385,30 @@
 				"node": ">=10.10.0"
 			}
 		},
+		"node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -339,8 +436,7 @@
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@humanwhocodes/retry": {
 			"version": "0.4.3",
@@ -356,10 +452,28 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
+		"node_modules/@ibm-cloud/watsonx-ai": {
+			"version": "1.7.10",
+			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.10.tgz",
+			"integrity": "sha512-+ckgkR/qLQSG5hmVrD3OywWGEmY8Vgo3WR3T0jGJxcO9w89gPwgQENn3qFnhF0YlILGEl4zNPuTYYDj1MtNSng==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "^18.0.0",
+				"extend": "3.0.2",
+				"form-data": "^4.0.4",
+				"ibm-cloud-sdk-core": "^5.4.5",
+				"ts-node": "^10.9.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
 		"node_modules/@inquirer/ansi": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.1.tgz",
-			"integrity": "sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+			"integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -367,17 +481,17 @@
 			}
 		},
 		"node_modules/@inquirer/checkbox": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.0.tgz",
-			"integrity": "sha512-5+Q3PKH35YsnoPTh75LucALdAxom6xh5D1oeY561x4cqBuH24ZFVyFREPe14xgnrtmGu3EEt1dIi60wRVSnGCw==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+			"integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/ansi": "^1.0.1",
-				"@inquirer/core": "^10.3.0",
-				"@inquirer/figures": "^1.0.14",
-				"@inquirer/type": "^3.0.9",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -392,14 +506,14 @@
 			}
 		},
 		"node_modules/@inquirer/confirm": {
-			"version": "5.1.19",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.19.tgz",
-			"integrity": "sha512-wQNz9cfcxrtEnUyG5PndC8g3gZ7lGDBzmWiXZkX8ot3vfZ+/BLjR8EvyGX4YzQLeVqtAlY/YScZpW7CW8qMoDQ==",
+			"version": "5.1.21",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+			"integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.0",
-				"@inquirer/type": "^3.0.9"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
 			},
 			"engines": {
 				"node": ">=18"
@@ -414,20 +528,20 @@
 			}
 		},
 		"node_modules/@inquirer/core": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.0.tgz",
-			"integrity": "sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==",
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+			"integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/ansi": "^1.0.1",
-				"@inquirer/figures": "^1.0.14",
-				"@inquirer/type": "^3.0.9",
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
 				"cli-width": "^4.1.0",
 				"mute-stream": "^2.0.0",
 				"signal-exit": "^4.1.0",
 				"wrap-ansi": "^6.2.0",
-				"yoctocolors-cjs": "^2.1.2"
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -449,6 +563,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/@inquirer/core/node_modules/strip-ansi": {
@@ -480,15 +610,15 @@
 			}
 		},
 		"node_modules/@inquirer/editor": {
-			"version": "4.2.21",
-			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.21.tgz",
-			"integrity": "sha512-MjtjOGjr0Kh4BciaFShYpZ1s9400idOdvQ5D7u7lE6VztPFoyLcVNE5dXBmEEIQq5zi4B9h2kU+q7AVBxJMAkQ==",
+			"version": "4.2.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+			"integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.0",
-				"@inquirer/external-editor": "^1.0.2",
-				"@inquirer/type": "^3.0.9"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/external-editor": "^1.0.3",
+				"@inquirer/type": "^3.0.10"
 			},
 			"engines": {
 				"node": ">=18"
@@ -503,15 +633,15 @@
 			}
 		},
 		"node_modules/@inquirer/expand": {
-			"version": "4.0.21",
-			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.21.tgz",
-			"integrity": "sha512-+mScLhIcbPFmuvU3tAGBed78XvYHSvCl6dBiYMlzCLhpr0bzGzd8tfivMMeqND6XZiaZ1tgusbUHJEfc6YzOdA==",
+			"version": "4.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+			"integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.0",
-				"@inquirer/type": "^3.0.9",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -526,13 +656,13 @@
 			}
 		},
 		"node_modules/@inquirer/external-editor": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
-			"integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+			"integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"chardet": "^2.1.0",
+				"chardet": "^2.1.1",
 				"iconv-lite": "^0.7.0"
 			},
 			"engines": {
@@ -548,9 +678,9 @@
 			}
 		},
 		"node_modules/@inquirer/figures": {
-			"version": "1.0.14",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
-			"integrity": "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==",
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+			"integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -558,14 +688,14 @@
 			}
 		},
 		"node_modules/@inquirer/input": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.5.tgz",
-			"integrity": "sha512-7GoWev7P6s7t0oJbenH0eQ0ThNdDJbEAEtVt9vsrYZ9FulIokvd823yLyhQlWHJPGce1wzP53ttfdCZmonMHyA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+			"integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.0",
-				"@inquirer/type": "^3.0.9"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
 			},
 			"engines": {
 				"node": ">=18"
@@ -580,14 +710,14 @@
 			}
 		},
 		"node_modules/@inquirer/number": {
-			"version": "3.0.21",
-			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.21.tgz",
-			"integrity": "sha512-5QWs0KGaNMlhbdhOSCFfKsW+/dcAVC2g4wT/z2MCiZM47uLgatC5N20kpkDQf7dHx+XFct/MJvvNGy6aYJn4Pw==",
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+			"integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.0",
-				"@inquirer/type": "^3.0.9"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
 			},
 			"engines": {
 				"node": ">=18"
@@ -602,15 +732,15 @@
 			}
 		},
 		"node_modules/@inquirer/password": {
-			"version": "4.0.21",
-			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.21.tgz",
-			"integrity": "sha512-xxeW1V5SbNFNig2pLfetsDb0svWlKuhmr7MPJZMYuDnCTkpVBI+X/doudg4pznc1/U+yYmWFFOi4hNvGgUo7EA==",
+			"version": "4.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+			"integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/ansi": "^1.0.1",
-				"@inquirer/core": "^10.3.0",
-				"@inquirer/type": "^3.0.9"
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
 			},
 			"engines": {
 				"node": ">=18"
@@ -625,22 +755,22 @@
 			}
 		},
 		"node_modules/@inquirer/prompts": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.9.0.tgz",
-			"integrity": "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==",
+			"version": "7.10.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+			"integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/checkbox": "^4.3.0",
-				"@inquirer/confirm": "^5.1.19",
-				"@inquirer/editor": "^4.2.21",
-				"@inquirer/expand": "^4.0.21",
-				"@inquirer/input": "^4.2.5",
-				"@inquirer/number": "^3.0.21",
-				"@inquirer/password": "^4.0.21",
-				"@inquirer/rawlist": "^4.1.9",
-				"@inquirer/search": "^3.2.0",
-				"@inquirer/select": "^4.4.0"
+				"@inquirer/checkbox": "^4.3.2",
+				"@inquirer/confirm": "^5.1.21",
+				"@inquirer/editor": "^4.2.23",
+				"@inquirer/expand": "^4.0.23",
+				"@inquirer/input": "^4.3.1",
+				"@inquirer/number": "^3.0.23",
+				"@inquirer/password": "^4.0.23",
+				"@inquirer/rawlist": "^4.1.11",
+				"@inquirer/search": "^3.2.2",
+				"@inquirer/select": "^4.4.2"
 			},
 			"engines": {
 				"node": ">=18"
@@ -655,15 +785,15 @@
 			}
 		},
 		"node_modules/@inquirer/rawlist": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.9.tgz",
-			"integrity": "sha512-AWpxB7MuJrRiSfTKGJ7Y68imYt8P9N3Gaa7ySdkFj1iWjr6WfbGAhdZvw/UnhFXTHITJzxGUI9k8IX7akAEBCg==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+			"integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.0",
-				"@inquirer/type": "^3.0.9",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -678,16 +808,16 @@
 			}
 		},
 		"node_modules/@inquirer/search": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.0.tgz",
-			"integrity": "sha512-a5SzB/qrXafDX1Z4AZW3CsVoiNxcIYCzYP7r9RzrfMpaLpB+yWi5U8BWagZyLmwR0pKbbL5umnGRd0RzGVI8bQ==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+			"integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.3.0",
-				"@inquirer/figures": "^1.0.14",
-				"@inquirer/type": "^3.0.9",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -702,17 +832,17 @@
 			}
 		},
 		"node_modules/@inquirer/select": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.0.tgz",
-			"integrity": "sha512-kaC3FHsJZvVyIjYBs5Ih8y8Bj4P/QItQWrZW22WJax7zTN+ZPXVGuOM55vzbdCP9zKUiBd9iEJVdesujfF+cAA==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+			"integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/ansi": "^1.0.1",
-				"@inquirer/core": "^10.3.0",
-				"@inquirer/figures": "^1.0.14",
-				"@inquirer/type": "^3.0.9",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -727,9 +857,9 @@
 			}
 		},
 		"node_modules/@inquirer/type": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.9.tgz",
-			"integrity": "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==",
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+			"integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -744,101 +874,930 @@
 				}
 			}
 		},
-		"node_modules/@isaacs/balanced-match": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@isaacs/brace-expansion": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@isaacs/balanced-match": "^4.0.1"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
 		"node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+			"integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
 			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@isaacs/cliui/node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
-		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+		"node_modules/@langchain/classic": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@langchain/classic/-/classic-1.0.5.tgz",
+			"integrity": "sha512-yMlcuQ80iG0SAEzgym95oLS+bJZJlmsFrMb+qkwg5mzHfL9DzAIFyvaMPiDnwKM0iv52u7iwD/aucLljZul9mQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
+				"@langchain/openai": "1.1.3",
+				"@langchain/textsplitters": "1.0.1",
+				"handlebars": "^4.7.8",
+				"js-yaml": "^4.1.1",
+				"jsonpointer": "^5.0.1",
+				"openapi-types": "^12.1.3",
+				"p-retry": "^7.0.0",
+				"uuid": "^10.0.0",
+				"yaml": "^2.2.1",
+				"zod": "^3.25.76 || ^4"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"langsmith": "^0.3.64"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.0",
+				"cheerio": "*",
+				"peggy": "^3.0.2",
+				"typeorm": "*"
+			},
+			"peerDependenciesMeta": {
+				"cheerio": {
+					"optional": true
+				},
+				"peggy": {
+					"optional": true
+				},
+				"typeorm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/classic/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@langchain/community": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/@langchain/community/-/community-1.1.14.tgz",
+			"integrity": "sha512-Jb64jqkjwocfK04RYW8oP9Z0VO3E1LfSlOx5QK3g7LJI7zQN8o1QzVvfXWigKQRuvMYue+X7DkunLaiEx/mohA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@langchain/classic": "1.0.17",
+				"@langchain/openai": "1.2.7",
+				"binary-extensions": "^2.2.0",
+				"flat": "^5.0.2",
+				"js-yaml": "^4.1.1",
+				"math-expression-evaluator": "^2.0.0",
+				"uuid": "^10.0.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@arcjet/redact": "^v1.1.0",
+				"@aws-crypto/sha256-js": "^5.0.0",
+				"@aws-sdk/client-dynamodb": "^3.985.0",
+				"@aws-sdk/client-lambda": "^3.985.0",
+				"@aws-sdk/client-s3": "^3.985.0",
+				"@aws-sdk/client-sagemaker-runtime": "^3.985.0",
+				"@aws-sdk/client-sfn": "^3.985.0",
+				"@aws-sdk/credential-provider-node": "^3.388.0",
+				"@azure/search-documents": "^12.2.0",
+				"@azure/storage-blob": "^12.30.0",
+				"@browserbasehq/sdk": "*",
+				"@browserbasehq/stagehand": "^1.0.0",
+				"@clickhouse/client": "^0.2.5",
+				"@datastax/astra-db-ts": "^1.0.0",
+				"@elastic/elasticsearch": "^8.4.0",
+				"@getmetal/metal-sdk": "*",
+				"@getzep/zep-cloud": "^1.0.6",
+				"@getzep/zep-js": "^0.9.0",
+				"@gomomento/sdk-core": "^1.117.2",
+				"@google-cloud/storage": "^6.10.1 || ^7.7.0",
+				"@gradientai/nodejs-sdk": "^1.2.0",
+				"@huggingface/inference": "^4.13.11",
+				"@huggingface/transformers": "^3.8.1",
+				"@ibm-cloud/watsonx-ai": "*",
+				"@lancedb/lancedb": "^0.19.1",
+				"@langchain/core": "^1.1.21",
+				"@layerup/layerup-security": "^1.5.12",
+				"@libsql/client": "^0.17.0",
+				"@mendable/firecrawl-js": "^1.4.3",
+				"@mlc-ai/web-llm": "*",
+				"@mozilla/readability": "*",
+				"@neondatabase/serverless": "*",
+				"@notionhq/client": "^2.2.10",
+				"@opensearch-project/opensearch": "*",
+				"@planetscale/database": "^1.8.0",
+				"@premai/prem-sdk": "^0.3.25",
+				"@raycast/api": "^1.55.2",
+				"@rockset/client": "^0.9.1",
+				"@smithy/eventstream-codec": "^2.0.5",
+				"@smithy/protocol-http": "^3.0.6",
+				"@smithy/signature-v4": "^2.0.10",
+				"@smithy/util-utf8": "^2.0.0",
+				"@spider-cloud/spider-client": "^0.1.85",
+				"@supabase/supabase-js": "^2.45.0",
+				"@tensorflow-models/universal-sentence-encoder": "*",
+				"@tensorflow/tfjs-core": "*",
+				"@upstash/ratelimit": "^1.1.3 || ^2.0.3",
+				"@upstash/redis": "^1.20.6",
+				"@upstash/vector": "^1.1.1",
+				"@vercel/kv": "*",
+				"@vercel/postgres": "*",
+				"@writerai/writer-sdk": "^0.40.2",
+				"@xata.io/client": "^0.28.0",
+				"@zilliz/milvus2-sdk-node": ">=2.3.5",
+				"apify-client": "^2.22.0",
+				"assemblyai": "^4.23.0",
+				"azion": "^3.0.0",
+				"better-sqlite3": ">=9.4.0 <12.0.0",
+				"cassandra-driver": "^4.7.2",
+				"cborg": "^4.5.8",
+				"cheerio": "^1.0.0-rc.12",
+				"chromadb": "*",
+				"closevector-common": "0.1.3",
+				"closevector-node": "0.1.6",
+				"closevector-web": "0.1.6",
+				"convex": "^1.3.1",
+				"couchbase": "^4.6.0",
+				"crypto-js": "^4.2.0",
+				"d3-dsv": "^2.0.0",
+				"discord.js": "^14.25.1",
+				"duck-duck-scrape": "^2.2.5",
+				"epub2": "^3.0.1",
+				"faiss-node": "*",
+				"fast-xml-parser": "*",
+				"firebase-admin": "^13.6.1",
+				"google-auth-library": "*",
+				"googleapis": "*",
+				"hnswlib-node": "^3.0.0",
+				"html-to-text": "^9.0.5",
+				"ibm-cloud-sdk-core": "*",
+				"ignore": "^5.2.0",
+				"interface-datastore": "^8.2.11",
+				"ioredis": "^5.3.2",
+				"it-all": "^3.0.4",
+				"jsdom": "*",
+				"jsonwebtoken": "^9.0.3",
+				"lodash": "^4.17.23",
+				"lunary": "^0.7.10",
+				"mammoth": "^1.11.0",
+				"mariadb": "^3.4.0",
+				"mem0ai": "^2.1.8",
+				"mysql2": "^3.16.3",
+				"neo4j-driver": "*",
+				"node-llama-cpp": ">=3.0.0",
+				"notion-to-md": "^3.1.0",
+				"officeparser": "^4.0.4",
+				"openai": "*",
+				"pdf-parse": "1.1.1",
+				"pg": "^8.11.0",
+				"pg-copy-streams": "^6.0.5",
+				"pickleparser": "^0.2.1",
+				"playwright": "^1.58.2",
+				"portkey-ai": "^0.1.11",
+				"puppeteer": "*",
+				"pyodide": ">=0.24.1 <0.27.0",
+				"replicate": "*",
+				"sonix-speech-recognition": "^2.1.1",
+				"srt-parser-2": "^1.2.3",
+				"typeorm": "^0.3.28",
+				"typesense": "^3.0.1",
+				"usearch": "^1.1.1",
+				"voy-search": "0.6.2",
+				"word-extractor": "*",
+				"ws": "^8.14.2",
+				"youtubei.js": "*"
+			},
+			"peerDependenciesMeta": {
+				"@arcjet/redact": {
+					"optional": true
+				},
+				"@aws-crypto/sha256-js": {
+					"optional": true
+				},
+				"@aws-sdk/client-dynamodb": {
+					"optional": true
+				},
+				"@aws-sdk/client-lambda": {
+					"optional": true
+				},
+				"@aws-sdk/client-s3": {
+					"optional": true
+				},
+				"@aws-sdk/client-sagemaker-runtime": {
+					"optional": true
+				},
+				"@aws-sdk/client-sfn": {
+					"optional": true
+				},
+				"@aws-sdk/credential-provider-node": {
+					"optional": true
+				},
+				"@aws-sdk/dsql-signer": {
+					"optional": true
+				},
+				"@azure/search-documents": {
+					"optional": true
+				},
+				"@azure/storage-blob": {
+					"optional": true
+				},
+				"@browserbasehq/sdk": {
+					"optional": true
+				},
+				"@clickhouse/client": {
+					"optional": true
+				},
+				"@datastax/astra-db-ts": {
+					"optional": true
+				},
+				"@elastic/elasticsearch": {
+					"optional": true
+				},
+				"@getmetal/metal-sdk": {
+					"optional": true
+				},
+				"@getzep/zep-cloud": {
+					"optional": true
+				},
+				"@getzep/zep-js": {
+					"optional": true
+				},
+				"@gomomento/sdk-core": {
+					"optional": true
+				},
+				"@google-cloud/storage": {
+					"optional": true
+				},
+				"@gradientai/nodejs-sdk": {
+					"optional": true
+				},
+				"@huggingface/inference": {
+					"optional": true
+				},
+				"@huggingface/transformers": {
+					"optional": true
+				},
+				"@lancedb/lancedb": {
+					"optional": true
+				},
+				"@layerup/layerup-security": {
+					"optional": true
+				},
+				"@libsql/client": {
+					"optional": true
+				},
+				"@mendable/firecrawl-js": {
+					"optional": true
+				},
+				"@mlc-ai/web-llm": {
+					"optional": true
+				},
+				"@mozilla/readability": {
+					"optional": true
+				},
+				"@neondatabase/serverless": {
+					"optional": true
+				},
+				"@notionhq/client": {
+					"optional": true
+				},
+				"@opensearch-project/opensearch": {
+					"optional": true
+				},
+				"@pinecone-database/pinecone": {
+					"optional": true
+				},
+				"@planetscale/database": {
+					"optional": true
+				},
+				"@premai/prem-sdk": {
+					"optional": true
+				},
+				"@qdrant/js-client-rest": {
+					"optional": true
+				},
+				"@raycast/api": {
+					"optional": true
+				},
+				"@rockset/client": {
+					"optional": true
+				},
+				"@smithy/eventstream-codec": {
+					"optional": true
+				},
+				"@smithy/protocol-http": {
+					"optional": true
+				},
+				"@smithy/signature-v4": {
+					"optional": true
+				},
+				"@smithy/util-utf8": {
+					"optional": true
+				},
+				"@spider-cloud/spider-client": {
+					"optional": true
+				},
+				"@supabase/supabase-js": {
+					"optional": true
+				},
+				"@tensorflow-models/universal-sentence-encoder": {
+					"optional": true
+				},
+				"@tensorflow/tfjs-core": {
+					"optional": true
+				},
+				"@upstash/ratelimit": {
+					"optional": true
+				},
+				"@upstash/redis": {
+					"optional": true
+				},
+				"@upstash/vector": {
+					"optional": true
+				},
+				"@vercel/kv": {
+					"optional": true
+				},
+				"@vercel/postgres": {
+					"optional": true
+				},
+				"@writerai/writer-sdk": {
+					"optional": true
+				},
+				"@xata.io/client": {
+					"optional": true
+				},
+				"@xenova/transformers": {
+					"optional": true
+				},
+				"@zilliz/milvus2-sdk-node": {
+					"optional": true
+				},
+				"apify-client": {
+					"optional": true
+				},
+				"assemblyai": {
+					"optional": true
+				},
+				"azion": {
+					"optional": true
+				},
+				"better-sqlite3": {
+					"optional": true
+				},
+				"cassandra-driver": {
+					"optional": true
+				},
+				"cborg": {
+					"optional": true
+				},
+				"cheerio": {
+					"optional": true
+				},
+				"chromadb": {
+					"optional": true
+				},
+				"closevector-common": {
+					"optional": true
+				},
+				"closevector-node": {
+					"optional": true
+				},
+				"closevector-web": {
+					"optional": true
+				},
+				"cohere-ai": {
+					"optional": true
+				},
+				"convex": {
+					"optional": true
+				},
+				"couchbase": {
+					"optional": true
+				},
+				"crypto-js": {
+					"optional": true
+				},
+				"d3-dsv": {
+					"optional": true
+				},
+				"discord.js": {
+					"optional": true
+				},
+				"duck-duck-scrape": {
+					"optional": true
+				},
+				"epub2": {
+					"optional": true
+				},
+				"faiss-node": {
+					"optional": true
+				},
+				"fast-xml-parser": {
+					"optional": true
+				},
+				"firebase-admin": {
+					"optional": true
+				},
+				"google-auth-library": {
+					"optional": true
+				},
+				"googleapis": {
+					"optional": true
+				},
+				"hnswlib-node": {
+					"optional": true
+				},
+				"html-to-text": {
+					"optional": true
+				},
+				"ignore": {
+					"optional": true
+				},
+				"interface-datastore": {
+					"optional": true
+				},
+				"ioredis": {
+					"optional": true
+				},
+				"it-all": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"jsonwebtoken": {
+					"optional": true
+				},
+				"lodash": {
+					"optional": true
+				},
+				"lunary": {
+					"optional": true
+				},
+				"mammoth": {
+					"optional": true
+				},
+				"mariadb": {
+					"optional": true
+				},
+				"mem0ai": {
+					"optional": true
+				},
+				"mongodb": {
+					"optional": true
+				},
+				"mysql2": {
+					"optional": true
+				},
+				"neo4j-driver": {
+					"optional": true
+				},
+				"node-llama-cpp": {
+					"optional": true
+				},
+				"notion-to-md": {
+					"optional": true
+				},
+				"officeparser": {
+					"optional": true
+				},
+				"pdf-parse": {
+					"optional": true
+				},
+				"pg": {
+					"optional": true
+				},
+				"pg-copy-streams": {
+					"optional": true
+				},
+				"pickleparser": {
+					"optional": true
+				},
+				"playwright": {
+					"optional": true
+				},
+				"portkey-ai": {
+					"optional": true
+				},
+				"puppeteer": {
+					"optional": true
+				},
+				"pyodide": {
+					"optional": true
+				},
+				"redis": {
+					"optional": true
+				},
+				"replicate": {
+					"optional": true
+				},
+				"sonix-speech-recognition": {
+					"optional": true
+				},
+				"srt-parser-2": {
+					"optional": true
+				},
+				"typeorm": {
+					"optional": true
+				},
+				"typesense": {
+					"optional": true
+				},
+				"usearch": {
+					"optional": true
+				},
+				"voy-search": {
+					"optional": true
+				},
+				"weaviate-client": {
+					"optional": true
+				},
+				"word-extractor": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				},
+				"youtubei.js": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/community/node_modules/@langchain/classic": {
+			"version": "1.0.17",
+			"resolved": "https://registry.npmjs.org/@langchain/classic/-/classic-1.0.17.tgz",
+			"integrity": "sha512-GgcmDILxl26E0Oo09Q/fotJB3EZrTnU4MuJGR2zQXPMZnZ1CCQqyecXjKDRdI6sZkfc8Kxg+ezT+0kIMtKV10A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@langchain/openai": "1.2.7",
+				"@langchain/textsplitters": "1.0.1",
+				"handlebars": "^4.7.8",
+				"js-yaml": "^4.1.1",
+				"jsonpointer": "^5.0.1",
+				"openapi-types": "^12.1.3",
+				"uuid": "^10.0.0",
+				"yaml": "^2.2.1",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"langsmith": ">=0.4.0 <1.0.0"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.0",
+				"cheerio": "*",
+				"peggy": "^3.0.2",
+				"typeorm": "*"
+			},
+			"peerDependenciesMeta": {
+				"cheerio": {
+					"optional": true
+				},
+				"peggy": {
+					"optional": true
+				},
+				"typeorm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/community/node_modules/@langchain/openai": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.2.7.tgz",
+			"integrity": "sha512-vR9zoF0/EZ03X0Tc6woIEWRDSDSr2l64n+MQCW8NduScJtBJs5r/Ng3Lrp2bjtJQywEMQoOhcrV2DMmAIPWgnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tiktoken": "^1.0.12",
+				"openai": "^6.18.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.0"
+			}
+		},
+		"node_modules/@langchain/community/node_modules/@langchain/openai/node_modules/openai": {
+			"version": "6.32.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.32.0.tgz",
+			"integrity": "sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/community/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@langchain/community/node_modules/langsmith": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.11.tgz",
+			"integrity": "sha512-Yio502Ow2vbVt16P1sybNMNpMsr5BMqoeonoi4flrcDsP55No/aCe2zydtBNOv0+kjKQw4WSKAzTsNwenDeD5w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/uuid": "^10.0.0",
+				"chalk": "^5.6.2",
+				"console-table-printer": "^2.12.1",
+				"p-queue": "^6.6.2",
+				"semver": "^7.6.3",
+				"uuid": "^10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*",
+				"ws": ">=7"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/community/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@langchain/core": {
+			"version": "1.1.34",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.34.tgz",
+			"integrity": "sha512-IDlZES5Vexo5meLQRCGkAU7NM0tPGPfPP5wcUzBd7Ot+JoFBmSXutC4gGzvZod5AKRVn3I0Qy5k8vkTraY21jA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@cfworker/json-schema": "^4.0.2",
+				"@standard-schema/spec": "^1.1.0",
+				"ansi-styles": "^5.0.0",
+				"camelcase": "6",
+				"decamelize": "1.2.0",
+				"js-tiktoken": "^1.0.12",
+				"langsmith": ">=0.5.0 <1.0.0",
+				"mustache": "^4.2.0",
+				"p-queue": "^6.6.2",
+				"uuid": "^11.1.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@langchain/core/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@langchain/core/node_modules/langsmith": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.11.tgz",
+			"integrity": "sha512-Yio502Ow2vbVt16P1sybNMNpMsr5BMqoeonoi4flrcDsP55No/aCe2zydtBNOv0+kjKQw4WSKAzTsNwenDeD5w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/uuid": "^10.0.0",
+				"chalk": "^5.6.2",
+				"console-table-printer": "^2.12.1",
+				"p-queue": "^6.6.2",
+				"semver": "^7.6.3",
+				"uuid": "^10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*",
+				"ws": ">=7"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/core/node_modules/langsmith/node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@langchain/core/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
+		"node_modules/@langchain/core/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@langchain/langgraph-checkpoint": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
+			"integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"uuid": "^10.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.1"
+			}
+		},
+		"node_modules/@langchain/openai": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.1.3.tgz",
+			"integrity": "sha512-p+xR+4HRms5Ozjf5miC6U2AYRyNVSTdO7AMBkMYs1Tp6DWHBd+mQ72H8Ogd2dKrPuS5UDJ5dbpI1fS+OrTbgQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tiktoken": "^1.0.12",
+				"openai": "^6.9.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.0"
+			}
+		},
+		"node_modules/@langchain/openai/node_modules/openai": {
+			"version": "6.32.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.32.0.tgz",
+			"integrity": "sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/openai/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@langchain/textsplitters": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@langchain/textsplitters/-/textsplitters-1.0.1.tgz",
+			"integrity": "sha512-rheJlB01iVtrOUzttscutRgLybPH9qR79EyzBEbf1u97ljWyuxQfCwIWK+SjoQTM9O8M7GGLLRBSYE26Jmcoww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tiktoken": "^1.0.12"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.0.0"
 			}
 		},
 		"node_modules/@n8n_io/riot-tmpl": {
@@ -846,25 +1805,355 @@
 			"resolved": "https://registry.npmjs.org/@n8n_io/riot-tmpl/-/riot-tmpl-4.0.1.tgz",
 			"integrity": "sha512-/zdRbEfTFjsm1NqnpPQHgZTkTdbp5v3VUxGeMA9098sps8jRCTraQkc3AQstJgHUm7ylBXJcIVhnVeLUMWAfwQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"eslint-config-riot": "^1.0.0"
 			}
 		},
-		"node_modules/@n8n/errors": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.5.0.tgz",
-			"integrity": "sha512-0Vk1Eb3Uor+zeF/WVnuhFgJc51wEBTZNBlVQy3mvyr3sGmW86bP1jA7wmRsd0DZbswPwN0vNOl/TmkDTEopOtQ==",
+		"node_modules/@n8n/ai-node-sdk": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.4.0.tgz",
+			"integrity": "sha512-9+t69B+EQeq1yC3qWFysGEyrWXWog2XpIOXoqFnfV5ZQKd+IUSEgTKVpb13UoMcmM1oRaLcZ4onvcORh1z8FvQ==",
+			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@n8n/ai-utilities": "0.6.0"
+			}
+		},
+		"node_modules/@n8n/ai-utilities": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.6.0.tgz",
+			"integrity": "sha512-QZUTViZchpHFdzlhM14P7s+tnjoPqup+Dri3FRWpbXGIRZ6no5htXuDZa2EaHxfJzJagT30Em3n14Te3x3y1iA==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@langchain/classic": "1.0.5",
+				"@langchain/community": "1.1.14",
+				"@langchain/core": "1.1.8",
+				"@langchain/openai": "1.1.3",
+				"@langchain/textsplitters": "1.0.1",
+				"@n8n/config": "2.11.0",
+				"@n8n/typescript-config": "1.3.0",
+				"https-proxy-agent": "7.0.6",
+				"js-tiktoken": "1.0.12",
+				"langchain": "1.2.3",
+				"proxy-from-env": "^1.1.0",
+				"tmp-promise": "3.0.3",
+				"undici": "^6.21.0",
+				"zod": "3.25.67",
+				"zod-to-json-schema": "3.23.3"
+			},
+			"peerDependencies": {
+				"n8n-workflow": "*"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.8.tgz",
+			"integrity": "sha512-kIUidOgc0ZdyXo4Ahn9Zas+OayqOfk4ZoKPi7XaDipNSWSApc2+QK5BVcjvwtzxstsNOrmXJiJWEN6WPF/MvAw==",
+			"dev": true,
+			"license": "MIT",
 			"peer": true,
+			"dependencies": {
+				"@cfworker/json-schema": "^4.0.2",
+				"ansi-styles": "^5.0.0",
+				"camelcase": "6",
+				"decamelize": "1.2.0",
+				"js-tiktoken": "^1.0.12",
+				"langsmith": ">=0.4.0 <1.0.0",
+				"mustache": "^4.2.0",
+				"p-queue": "^6.6.2",
+				"uuid": "^10.0.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/langsmith": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.11.tgz",
+			"integrity": "sha512-Yio502Ow2vbVt16P1sybNMNpMsr5BMqoeonoi4flrcDsP55No/aCe2zydtBNOv0+kjKQw4WSKAzTsNwenDeD5w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/uuid": "^10.0.0",
+				"chalk": "^5.6.2",
+				"console-table-printer": "^2.12.1",
+				"p-queue": "^6.6.2",
+				"semver": "^7.6.3",
+				"uuid": "^10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*",
+				"ws": ">=7"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/langchain": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/langchain/-/langchain-1.2.3.tgz",
+			"integrity": "sha512-3k986xJuqg4az53JxV5LnGlOzIXF1d9Kq6Y9s7XjitvzhpsbFuTDV5/kiF4cx3pkNGyw0mUXC4tLz9RxucO0hw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@langchain/langgraph": "^1.0.0",
+				"@langchain/langgraph-checkpoint": "^1.0.0",
+				"langsmith": ">=0.4.0 <1.0.0",
+				"uuid": "^10.0.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@langchain/core": "1.1.8"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/@langchain/langgraph": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.3.tgz",
+			"integrity": "sha512-wvc7cQ4t6aLmI3PtVvvpN7VTqEmQunrlVnuR6t7z/1l98bj6TnQg8uS+NiJ+gF2TkVC5YXkfqY8Z4EpdD6FlcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@langchain/langgraph-checkpoint": "^1.0.1",
+				"@langchain/langgraph-sdk": "~1.7.3",
+				"@standard-schema/spec": "1.1.0",
+				"uuid": "^10.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.1.16",
+				"zod": "^3.25.32 || ^4.2.0",
+				"zod-to-json-schema": "^3.x"
+			},
+			"peerDependenciesMeta": {
+				"zod-to-json-schema": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.7.4.tgz",
+			"integrity": "sha512-SuQyFvL9Q/eBJdSAHLaM1mmfKoh5JAmRF4PdIokX9pyVYBvJqUpvsOcUYtkC3zniHOh/65y1eqvojt/WgPvN8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15",
+				"p-queue": "^9.0.1",
+				"p-retry": "^7.1.1",
+				"uuid": "^13.0.0"
+			},
+			"peerDependencies": {
+				"@angular/core": "^18.0.0 || ^19.0.0 || ^20.0.0",
+				"@langchain/core": "^1.1.16",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19",
+				"svelte": "^4.0.0 || ^5.0.0",
+				"vue": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@angular/core": {
+					"optional": true
+				},
+				"@langchain/core": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/@langchain/langgraph/node_modules/p-queue": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
+			"integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eventemitter3": "^5.0.1",
+				"p-timeout": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/langsmith": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.11.tgz",
+			"integrity": "sha512-Yio502Ow2vbVt16P1sybNMNpMsr5BMqoeonoi4flrcDsP55No/aCe2zydtBNOv0+kjKQw4WSKAzTsNwenDeD5w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/uuid": "^10.0.0",
+				"chalk": "^5.6.2",
+				"console-table-printer": "^2.12.1",
+				"p-queue": "^6.6.2",
+				"semver": "^7.6.3",
+				"uuid": "^10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*",
+				"ws": ">=7"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/p-timeout": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+			"integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@n8n/config": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.11.0.tgz",
+			"integrity": "sha512-GdtJSLTHWpJp++fxiEar7vV3C2mKLAwNA1iurqW7DHizUVuRfGVrjTIAkR7VCvEDDioBpRnMGC6dK2hxdXphbQ==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@n8n/di": "0.10.0",
+				"reflect-metadata": "0.2.2",
+				"zod": "3.25.67"
+			}
+		},
+		"node_modules/@n8n/di": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.10.0.tgz",
+			"integrity": "sha512-wqVjmb/tfE1Dyax6607K5InLM89pHZvmVTfakv6y17XJSwu2JbkT/+FI1z2tQswoSlhBIH3N1BZSiYsVbP58bw==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"reflect-metadata": "0.2.2"
+			}
+		},
+		"node_modules/@n8n/errors": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.6.0.tgz",
+			"integrity": "sha512-oVJ0lgRYJY6/aPOW2h37ea5T+nX7/wULRn5FymwYeaiYlsLdqwIQEtGwZrajpzxJB0Os74u4lSH3WWQgZCkgxQ==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"callsites": "3.1.0"
 			}
 		},
 		"node_modules/@n8n/eslint-plugin-community-nodes": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.6.0.tgz",
-			"integrity": "sha512-VafBm+pHvOiO/DPZfdyYBHWS6ZEeu3jMwK3E1lxE7rXUbLlRoqW3YL4jnJ5R8JIChMVcZeoybGALt1lnuixyjA==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.9.0.tgz",
+			"integrity": "sha512-8PH129M3W34ihNTj79hXq95++puWUMGm7wTRH5NiLZZbiLyGwyv2CpZcT92uBehQ2pYc26TxzEbIvp8+MCU2Ow==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
@@ -875,27 +2164,45 @@
 				"eslint": ">= 9"
 			}
 		},
+		"node_modules/@n8n/expression-runtime": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.5.0.tgz",
+			"integrity": "sha512-DqkF79FyuljdjlSz1i6PfbrQ47w5U/fIqjoyAbRVxr+YatiM3RAe0zhfQ1ur1lV5QTq0BHnY8zsfFQ+DIItPhA==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@n8n/tournament": "1.0.6",
+				"isolated-vm": "^6.0.2",
+				"js-base64": "3.7.2",
+				"jssha": "3.3.1",
+				"lodash": "4.17.23",
+				"luxon": "3.7.2",
+				"md5": "2.3.0",
+				"title-case": "3.0.3",
+				"transliteration": "2.3.5"
+			}
+		},
 		"node_modules/@n8n/node-cli": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.13.0.tgz",
-			"integrity": "sha512-4YRA1r3D2k+qA2psKNQHd+g077slvJpRunyRt3etgI5Kmbo445wQJSMF03+f4Els1EP3AO7eN7F6HSTz0AHtzA==",
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.23.0.tgz",
+			"integrity": "sha512-O77A2BI5QC6W8nxDavDIWBvBUlAOEzZ0yuuXVs3vTduaOHMRAZaS0JH38KSKaFTOrOHpqHG8j2LukHsVRJZC0A==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@clack/prompts": "^0.11.0",
-				"@n8n/eslint-plugin-community-nodes": "0.6.0",
+				"@n8n/ai-node-sdk": "0.4.0",
+				"@n8n/eslint-plugin-community-nodes": "0.9.0",
 				"@oclif/core": "^4.5.2",
 				"change-case": "^5.4.4",
 				"eslint-import-resolver-typescript": "^4.4.3",
 				"eslint-plugin-import-x": "^4.15.2",
-				"eslint-plugin-n8n-nodes-base": "1.16.3",
+				"eslint-plugin-n8n-nodes-base": "1.16.5",
 				"fast-glob": "3.2.12",
 				"handlebars": "4.7.8",
 				"picocolors": "1.0.1",
 				"prettier": "3.6.2",
 				"prompts": "^2.4.2",
 				"rimraf": "6.0.1",
-				"ts-morph": "^26.0.0",
+				"ts-morph": "^27.0.2",
 				"typescript-eslint": "^8.35.0"
 			},
 			"bin": {
@@ -905,12 +2212,62 @@
 				"eslint": ">= 9"
 			}
 		},
+		"node_modules/@n8n/node-cli/node_modules/eslint-import-resolver-typescript": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
+			"integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"debug": "^4.4.1",
+				"eslint-import-context": "^0.1.8",
+				"get-tsconfig": "^4.10.1",
+				"is-bun-module": "^2.0.0",
+				"stable-hash-x": "^0.2.0",
+				"tinyglobby": "^0.2.14",
+				"unrs-resolver": "^1.7.11"
+			},
+			"engines": {
+				"node": "^16.17.0 || >=18.6.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-import-resolver-typescript"
+			},
+			"peerDependencies": {
+				"eslint": "*",
+				"eslint-plugin-import": "*",
+				"eslint-plugin-import-x": "*"
+			},
+			"peerDependenciesMeta": {
+				"eslint-plugin-import": {
+					"optional": true
+				},
+				"eslint-plugin-import-x": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@n8n/node-cli/node_modules/prettier": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
 		"node_modules/@n8n/tournament": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.0.6.tgz",
 			"integrity": "sha512-UGSxYXXVuOX0yL6HTLBStKYwLIa0+JmRKiSZSCMcM2s2Wax984KWT6XIA1TR/27i7yYpDk1MY14KsTPnuEp27A==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@n8n_io/riot-tmpl": "^4.0.1",
 				"ast-types": "^0.16.1",
@@ -922,18 +2279,12 @@
 				"pnpm": ">=9.5"
 			}
 		},
-		"node_modules/@n8n/tournament/node_modules/ast-types": {
-			"version": "0.16.1",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
-			"integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=4"
-			}
+		"node_modules/@n8n/typescript-config": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.3.0.tgz",
+			"integrity": "sha512-wnrHUHdyfL8PgwwwBDWUaEnRRjszLYMVv5NzXnPtRaiewz2reOWeruhFTL0aPjJioYT2LcB9dLelCA44ytnXAA==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "0.2.12",
@@ -997,9 +2348,9 @@
 			}
 		},
 		"node_modules/@oclif/core": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.5.5.tgz",
-			"integrity": "sha512-iQzlaJQgPeUXrtrX71OzDwxPikQ7c2FhNd8U8rBB7BCtj2XYfmzBT/Hmbc+g9OKDIG/JkbJT0fXaWMMBrhi+1A==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.9.0.tgz",
+			"integrity": "sha512-k/ntRgDcUprTT+aaNoF+whk3cY3f9fRD2lkF6ul7JeCUg2MaMXVXZXfbRhJCfsiX51X8/5Pqo0LGdO9SLYXNHg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1013,7 +2364,7 @@
 				"indent-string": "^4.0.0",
 				"is-wsl": "^2.2.0",
 				"lilconfig": "^3.1.3",
-				"minimatch": "^9.0.5",
+				"minimatch": "^10.2.4",
 				"semver": "^7.7.3",
 				"string-width": "^4.2.3",
 				"supports-color": "^8",
@@ -1037,17 +2388,18 @@
 			}
 		},
 		"node_modules/@octokit/core": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.5.tgz",
-			"integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^6.0.0",
-				"@octokit/graphql": "^9.0.2",
-				"@octokit/request": "^10.0.4",
-				"@octokit/request-error": "^7.0.1",
-				"@octokit/types": "^15.0.0",
+				"@octokit/graphql": "^9.0.3",
+				"@octokit/request": "^10.0.6",
+				"@octokit/request-error": "^7.0.2",
+				"@octokit/types": "^16.0.0",
 				"before-after-hook": "^4.0.0",
 				"universal-user-agent": "^7.0.0"
 			},
@@ -1056,13 +2408,13 @@
 			}
 		},
 		"node_modules/@octokit/endpoint": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.1.tgz",
-			"integrity": "sha512-7P1dRAZxuWAOPI7kXfio88trNi/MegQ0IJD3vfgC3b+LZo1Qe6gRJc2v0mz2USWWJOKrB2h5spXCzGbw+fAdqA==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+			"integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^15.0.0",
+				"@octokit/types": "^16.0.0",
 				"universal-user-agent": "^7.0.2"
 			},
 			"engines": {
@@ -1070,14 +2422,14 @@
 			}
 		},
 		"node_modules/@octokit/graphql": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.2.tgz",
-			"integrity": "sha512-iz6KzZ7u95Fzy9Nt2L8cG88lGRMr/qy1Q36ih/XVzMIlPDMYwaNLE/ENhqmIzgPrlNWiYJkwmveEetvxAgFBJw==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+			"integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/request": "^10.0.4",
-				"@octokit/types": "^15.0.0",
+				"@octokit/request": "^10.0.6",
+				"@octokit/types": "^16.0.0",
 				"universal-user-agent": "^7.0.0"
 			},
 			"engines": {
@@ -1085,20 +2437,20 @@
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "26.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
-			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA==",
+			"version": "27.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+			"integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.2.0.tgz",
-			"integrity": "sha512-YuAlyjR8o5QoRSOvMHxSJzPtogkNMgeMv2mpccrvdUGeC3MKyfi/hS+KiFwyH/iRKIKyx+eIMsDjbt3p9r2GYA==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+			"integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^15.0.0"
+				"@octokit/types": "^16.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
@@ -1121,13 +2473,13 @@
 			}
 		},
 		"node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "16.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-16.1.0.tgz",
-			"integrity": "sha512-nCsyiKoGRnhH5LkH8hJEZb9swpqOcsW+VXv1QoyUNQXJeVODG4+xM6UICEqyqe9XFr6LkL8BIiFCPev8zMDXPw==",
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+			"integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^15.0.0"
+				"@octokit/types": "^16.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
@@ -1137,16 +2489,17 @@
 			}
 		},
 		"node_modules/@octokit/request": {
-			"version": "10.0.5",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.5.tgz",
-			"integrity": "sha512-TXnouHIYLtgDhKo+N6mXATnDBkV05VwbR0TtMWpgTHIoQdRQfCSzmy/LGqR1AbRMbijq/EckC/E3/ZNcU92NaQ==",
+			"version": "10.0.8",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+			"integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/endpoint": "^11.0.1",
-				"@octokit/request-error": "^7.0.1",
-				"@octokit/types": "^15.0.0",
+				"@octokit/endpoint": "^11.0.3",
+				"@octokit/request-error": "^7.0.2",
+				"@octokit/types": "^16.0.0",
 				"fast-content-type-parse": "^3.0.0",
+				"json-with-bigint": "^3.5.3",
 				"universal-user-agent": "^7.0.2"
 			},
 			"engines": {
@@ -1154,43 +2507,50 @@
 			}
 		},
 		"node_modules/@octokit/request-error": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.1.tgz",
-			"integrity": "sha512-CZpFwV4+1uBrxu7Cw8E5NCXDWFNf18MSY23TdxCBgjw1tXXHvTrZVsXlW8hgFTOLw8RQR1BBrMvYRtuyaijHMA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+			"integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^15.0.0"
+				"@octokit/types": "^16.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
 			}
 		},
 		"node_modules/@octokit/rest": {
-			"version": "22.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.0.tgz",
-			"integrity": "sha512-z6tmTu9BTnw51jYGulxrlernpsQYXpui1RK21vmXn8yF5bp6iX16yfTtJYGK5Mh1qDkvDOmp2n8sRMcQmR8jiA==",
+			"version": "22.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+			"integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/core": "^7.0.2",
-				"@octokit/plugin-paginate-rest": "^13.0.1",
+				"@octokit/core": "^7.0.6",
+				"@octokit/plugin-paginate-rest": "^14.0.0",
 				"@octokit/plugin-request-log": "^6.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "^16.0.0"
+				"@octokit/plugin-rest-endpoint-methods": "^17.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
 			}
 		},
 		"node_modules/@octokit/types": {
-			"version": "15.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
-			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+			"integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^26.0.0"
+				"@octokit/openapi-types": "^27.0.0"
 			}
+		},
+		"node_modules/@package-json/types": {
+			"version": "0.0.12",
+			"resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
+			"integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@phun-ky/typeof": {
 			"version": "2.0.3",
@@ -1206,6 +2566,55 @@
 				"url": "https://github.com/phun-ky/typeof?sponsor=1"
 			}
 		},
+		"node_modules/@playwright/test": {
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"playwright": "1.58.2"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@tootallnate/quickjs-emscripten": {
 			"version": "0.23.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -1214,62 +2623,44 @@
 			"license": "MIT"
 		},
 		"node_modules/@ts-morph/common": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
-			"integrity": "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
+			"integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-glob": "^3.3.3",
 				"minimatch": "^10.0.1",
-				"path-browserify": "^1.0.1"
+				"path-browserify": "^1.0.1",
+				"tinyglobby": "^0.2.14"
 			}
 		},
-		"node_modules/@ts-morph/common/node_modules/fast-glob": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+		"node_modules/@tsconfig/node10": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+			"integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.2",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.8"
-			},
-			"engines": {
-				"node": ">=8.6.0"
-			}
+			"license": "MIT"
 		},
-		"node_modules/@ts-morph/common/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+		"node_modules/@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
 			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
+			"license": "MIT"
 		},
-		"node_modules/@ts-morph/common/node_modules/minimatch": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-			"integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
 			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@isaacs/brace-expansion": "^5.0.0"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node16": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.1",
@@ -1281,6 +2672,23 @@
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
+		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
+		"node_modules/@types/esrecurse": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
@@ -1296,6 +2704,35 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "18.19.130",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/@types/node-fetch": {
+			"version": "2.6.13",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+			"integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"form-data": "^4.0.4"
+			}
+		},
 		"node_modules/@types/parse-path": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
@@ -1310,22 +2747,35 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.46.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.1.tgz",
-			"integrity": "sha512-rUsLh8PXmBjdiPY+Emjz9NX2yHvhS11v0SR6xNJkm5GM1MO9ea/1GoDKlHHZGrOJclL/cZ2i/vRUYVtjRhrHVQ==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
+			"integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.46.1",
-				"@typescript-eslint/type-utils": "8.46.1",
-				"@typescript-eslint/utils": "8.46.1",
-				"@typescript-eslint/visitor-keys": "8.46.1",
-				"graphemer": "^1.4.0",
-				"ignore": "^7.0.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@typescript-eslint/scope-manager": "8.57.1",
+				"@typescript-eslint/type-utils": "8.57.1",
+				"@typescript-eslint/utils": "8.57.1",
+				"@typescript-eslint/visitor-keys": "8.57.1",
+				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
-				"ts-api-utils": "^2.1.0"
+				"ts-api-utils": "^2.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1335,8 +2785,8 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.46.1",
-				"eslint": "^8.57.0 || ^9.0.0",
+				"@typescript-eslint/parser": "^8.57.1",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
@@ -1351,17 +2801,18 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.46.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.1.tgz",
-			"integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
+			"integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.46.1",
-				"@typescript-eslint/types": "8.46.1",
-				"@typescript-eslint/typescript-estree": "8.46.1",
-				"@typescript-eslint/visitor-keys": "8.46.1",
-				"debug": "^4.3.4"
+				"@typescript-eslint/scope-manager": "8.57.1",
+				"@typescript-eslint/types": "8.57.1",
+				"@typescript-eslint/typescript-estree": "8.57.1",
+				"@typescript-eslint/visitor-keys": "8.57.1",
+				"debug": "^4.4.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1371,20 +2822,20 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.46.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.1.tgz",
-			"integrity": "sha512-FOIaFVMHzRskXr5J4Jp8lFVV0gz5ngv3RHmn+E4HYxSJ3DgDzU7fVI1/M7Ijh1zf6S7HIoaIOtln1H5y8V+9Zg==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
+			"integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.46.1",
-				"@typescript-eslint/types": "^8.46.1",
-				"debug": "^4.3.4"
+				"@typescript-eslint/tsconfig-utils": "^8.57.1",
+				"@typescript-eslint/types": "^8.57.1",
+				"debug": "^4.4.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1398,14 +2849,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.46.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.1.tgz",
-			"integrity": "sha512-weL9Gg3/5F0pVQKiF8eOXFZp8emqWzZsOJuWRUNtHT+UNV2xSJegmpCNQHy37aEQIbToTq7RHKhWvOsmbM680A==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
+			"integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.1",
-				"@typescript-eslint/visitor-keys": "8.46.1"
+				"@typescript-eslint/types": "8.57.1",
+				"@typescript-eslint/visitor-keys": "8.57.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1416,9 +2867,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.46.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.1.tgz",
-			"integrity": "sha512-X88+J/CwFvlJB+mK09VFqx5FE4H5cXD+H/Bdza2aEWkSb8hnWIQorNcscRl4IEo1Cz9VI/+/r/jnGWkbWPx54g==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
+			"integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1433,17 +2884,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.46.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.1.tgz",
-			"integrity": "sha512-+BlmiHIiqufBxkVnOtFwjah/vrkF4MtKKvpXrKSPLCkCtAp8H01/VV43sfqA98Od7nJpDcFnkwgyfQbOG0AMvw==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
+			"integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.1",
-				"@typescript-eslint/typescript-estree": "8.46.1",
-				"@typescript-eslint/utils": "8.46.1",
-				"debug": "^4.3.4",
-				"ts-api-utils": "^2.1.0"
+				"@typescript-eslint/types": "8.57.1",
+				"@typescript-eslint/typescript-estree": "8.57.1",
+				"@typescript-eslint/utils": "8.57.1",
+				"debug": "^4.4.3",
+				"ts-api-utils": "^2.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1453,14 +2904,14 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.46.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.1.tgz",
-			"integrity": "sha512-C+soprGBHwWBdkDpbaRC4paGBrkIXxVlNohadL5o0kfhsXqOC6GYH2S/Obmig+I0HTDl8wMaRySwrfrXVP8/pQ==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+			"integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1472,22 +2923,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.46.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.1.tgz",
-			"integrity": "sha512-uIifjT4s8cQKFQ8ZBXXyoUODtRoAd7F7+G8MKmtzj17+1UbdzFl52AzRyZRyKqPHhgzvXunnSckVu36flGy8cg==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
+			"integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.46.1",
-				"@typescript-eslint/tsconfig-utils": "8.46.1",
-				"@typescript-eslint/types": "8.46.1",
-				"@typescript-eslint/visitor-keys": "8.46.1",
-				"debug": "^4.3.4",
-				"fast-glob": "^3.3.2",
-				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
-				"ts-api-utils": "^2.1.0"
+				"@typescript-eslint/project-service": "8.57.1",
+				"@typescript-eslint/tsconfig-utils": "8.57.1",
+				"@typescript-eslint/types": "8.57.1",
+				"@typescript-eslint/visitor-keys": "8.57.1",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1500,47 +2950,18 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/fast-glob": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.2",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.8"
-			},
-			"engines": {
-				"node": ">=8.6.0"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.46.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.1.tgz",
-			"integrity": "sha512-vkYUy6LdZS7q1v/Gxb2Zs7zziuXN0wxqsetJdeZdRe/f5dwJFglmuvZBfTUivCtjH725C1jWCDfpadadD95EDQ==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
+			"integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.46.1",
-				"@typescript-eslint/types": "8.46.1",
-				"@typescript-eslint/typescript-estree": "8.46.1"
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.57.1",
+				"@typescript-eslint/types": "8.57.1",
+				"@typescript-eslint/typescript-estree": "8.57.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1550,19 +2971,19 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.46.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.1.tgz",
-			"integrity": "sha512-ptkmIf2iDkNUjdeu2bQqhFPV1m6qTnFFjg7PPDjxKWaMaP0Z6I9l30Jr3g5QqbZGdw8YdYvLp+XnqnWWZOg/NA==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
+			"integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.1",
-				"eslint-visitor-keys": "^4.2.1"
+				"@typescript-eslint/types": "8.57.1",
+				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1573,13 +2994,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -1590,8 +3011,7 @@
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
 			"version": "1.11.1",
@@ -1862,12 +3282,26 @@
 				"win32"
 			]
 		},
-		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1885,6 +3319,19 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.5",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1895,10 +3342,23 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/agentkeepalive": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+			"integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"humanize-ms": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1942,15 +3402,13 @@
 			}
 		},
 		"node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -1965,6 +3423,13 @@
 			"engines": {
 				"node": ">=14"
 			}
+		},
+		"node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -1988,7 +3453,6 @@
 			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
 			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"is-nan": "^1.3.2",
@@ -1998,11 +3462,10 @@
 			}
 		},
 		"node_modules/ast-types": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
-			"integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+			"integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.0.1"
 			},
@@ -2031,15 +3494,13 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
 			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"possible-typed-array-names": "^1.0.0"
 			},
@@ -2050,17 +3511,54 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+		"node_modules/axios": {
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+			"integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
 			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
+				"proxy-from-env": "^1.1.0"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
 			"license": "MIT"
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-			"integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+			"integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2074,14 +3572,30 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/binary-extensions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/braces": {
@@ -2096,6 +3610,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/bundle-name": {
 			"version": "4.1.0",
@@ -2114,19 +3635,19 @@
 			}
 		},
 		"node_modules/c12": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/c12/-/c12-3.3.0.tgz",
-			"integrity": "sha512-K9ZkuyeJQeqLEyqldbYLG3wjqwpw4BVaAqvmxq3GYKK0b1A/yYQdIcJxkzAOWcNVWhJpRXAPfZFueekiY/L8Dw==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
+			"integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"chokidar": "^4.0.3",
+				"chokidar": "^5.0.0",
 				"confbox": "^0.2.2",
 				"defu": "^6.1.4",
-				"dotenv": "^17.2.2",
-				"exsolve": "^1.0.7",
+				"dotenv": "^17.2.3",
+				"exsolve": "^1.0.8",
 				"giget": "^2.0.0",
-				"jiti": "^2.5.1",
+				"jiti": "^2.6.1",
 				"ohash": "^2.0.11",
 				"pathe": "^2.0.3",
 				"perfect-debounce": "^2.0.0",
@@ -2134,7 +3655,7 @@
 				"rc9": "^2.1.2"
 			},
 			"peerDependencies": {
-				"magicast": "^0.3.5"
+				"magicast": "*"
 			},
 			"peerDependenciesMeta": {
 				"magicast": {
@@ -2142,12 +3663,24 @@
 				}
 			}
 		},
+		"node_modules/c12/node_modules/dotenv": {
+			"version": "17.3.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+			"integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
 		"node_modules/call-bind": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
 			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.0",
 				"es-define-property": "^1.0.0",
@@ -2166,7 +3699,6 @@
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2"
@@ -2180,7 +3712,6 @@
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"get-intrinsic": "^1.3.0"
@@ -2212,6 +3743,19 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2227,6 +3771,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chalk/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/chalk/node_modules/supports-color": {
@@ -2250,9 +3810,9 @@
 			"license": "MIT"
 		},
 		"node_modules/chardet": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
-			"integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2261,31 +3821,30 @@
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"readdirp": "^4.0.1"
+				"readdirp": "^5.0.0"
 			},
 			"engines": {
-				"node": ">= 14.16.0"
+				"node": ">= 20.19.0"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/ci-info": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2368,7 +3927,6 @@
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -2383,7 +3941,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2393,7 +3950,6 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -2431,7 +3987,6 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
 			},
@@ -2440,9 +3995,9 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
-			"integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
+			"integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2457,9 +4012,9 @@
 			"license": "MIT"
 		},
 		"node_modules/confbox": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-			"integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+			"integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2472,6 +4027,23 @@
 			"engines": {
 				"node": "^14.18.0 || >=16.10.0"
 			}
+		},
+		"node_modules/console-table-printer": {
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
+			"integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"simple-wcswidth": "^1.1.2"
+			}
+		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -2493,7 +4065,6 @@
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
 			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -2526,6 +4097,16 @@
 				}
 			}
 		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2533,10 +4114,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/deepmerge": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/default-browser": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-			"integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2551,9 +4143,9 @@
 			}
 		},
 		"node_modules/default-browser-id": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-			"integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2568,7 +4160,6 @@
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
@@ -2599,7 +4190,6 @@
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
 			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
@@ -2652,7 +4242,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -2663,6 +4252,16 @@
 			"integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/diff": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -2683,7 +4282,6 @@
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -2692,11 +4290,12 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "17.2.3",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-			"integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -2709,7 +4308,6 @@
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
 				"es-errors": "^1.3.0",
@@ -2719,12 +4317,15 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"node_modules/ejs": {
 			"version": "3.1.10",
@@ -2753,7 +4354,6 @@
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -2763,7 +4363,6 @@
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -2773,9 +4372,23 @@
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
 			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -2786,7 +4399,6 @@
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
 			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2827,34 +4439,31 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.32.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
-			"integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
+			"integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.0",
-				"@eslint/config-helpers": "^0.3.0",
-				"@eslint/core": "^0.15.0",
-				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.32.0",
-				"@eslint/plugin-kit": "^0.3.4",
+				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@eslint/config-array": "^0.23.3",
+				"@eslint/config-helpers": "^0.5.2",
+				"@eslint/core": "^1.1.1",
+				"@eslint/plugin-kit": "^0.6.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
-				"@types/json-schema": "^7.0.15",
-				"ajv": "^6.12.4",
-				"chalk": "^4.0.0",
+				"ajv": "^6.14.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^8.4.0",
-				"eslint-visitor-keys": "^4.2.1",
-				"espree": "^10.4.0",
-				"esquery": "^1.5.0",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"espree": "^11.1.1",
+				"esquery": "^1.7.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^8.0.0",
@@ -2864,8 +4473,7 @@
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.2",
+				"minimatch": "^10.2.4",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -2873,7 +4481,7 @@
 				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://eslint.org/donate"
@@ -2891,8 +4499,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-riot/-/eslint-config-riot-1.0.0.tgz",
 			"integrity": "sha512-NB/L/1Y30qyJcG5xZxCJKW/+bqyj+llbcCwo9DEz8bESIP0SLTOQ8T1DWCCFc+wJ61AMEstj4511PSScqMMfCw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/eslint-import-context": {
 			"version": "0.1.9",
@@ -2919,54 +4526,21 @@
 				}
 			}
 		},
-		"node_modules/eslint-import-resolver-typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
-			"integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"debug": "^4.4.1",
-				"eslint-import-context": "^0.1.8",
-				"get-tsconfig": "^4.10.1",
-				"is-bun-module": "^2.0.0",
-				"stable-hash-x": "^0.2.0",
-				"tinyglobby": "^0.2.14",
-				"unrs-resolver": "^1.7.11"
-			},
-			"engines": {
-				"node": "^16.17.0 || >=18.6.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint-import-resolver-typescript"
-			},
-			"peerDependencies": {
-				"eslint": "*",
-				"eslint-plugin-import": "*",
-				"eslint-plugin-import-x": "*"
-			},
-			"peerDependenciesMeta": {
-				"eslint-plugin-import": {
-					"optional": true
-				},
-				"eslint-plugin-import-x": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/eslint-plugin-import-x": {
-			"version": "4.16.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.1.tgz",
-			"integrity": "sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
+			"integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "^8.35.0",
+				"@package-json/types": "^0.0.12",
+				"@typescript-eslint/types": "^8.56.0",
 				"comment-parser": "^1.4.1",
 				"debug": "^4.4.1",
 				"eslint-import-context": "^0.1.9",
 				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.3 || ^10.0.1",
+				"minimatch": "^9.0.3 || ^10.1.2",
 				"semver": "^7.7.2",
 				"stable-hash-x": "^0.2.0",
 				"unrs-resolver": "^1.9.2"
@@ -2978,8 +4552,8 @@
 				"url": "https://opencollective.com/eslint-plugin-import-x"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/utils": "^8.0.0",
-				"eslint": "^8.57.0 || ^9.0.0",
+				"@typescript-eslint/utils": "^8.56.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"eslint-import-resolver-node": "*"
 			},
 			"peerDependenciesMeta": {
@@ -2991,24 +4565,16 @@
 				}
 			}
 		},
-		"node_modules/eslint-plugin-local": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-local/-/eslint-plugin-local-1.0.0.tgz",
-			"integrity": "sha512-bcwcQnKL/Iw5Vi/F2lG1he5oKD2OGjhsLmrcctkWrWq5TujgiaYb0cj3pZgr3XI54inNVnneOFdAx1daLoYLJQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/eslint-plugin-n8n-nodes-base": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n8n-nodes-base/-/eslint-plugin-n8n-nodes-base-1.16.3.tgz",
-			"integrity": "sha512-edLX42Vg4B+y0kzkitTVDmHZQrG5/wUZO874N5Z9leBuxt5TG1pqMY4zdr35RlpM4p4REr/T9x+6DpsQSL63WA==",
+			"version": "1.16.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n8n-nodes-base/-/eslint-plugin-n8n-nodes-base-1.16.5.tgz",
+			"integrity": "sha512-/Bx2xj1ZzwEN+KQmnf7i0QRzgNMuphythQI2qXHoJQd8nm6aJGC9ZyVmDBFkM9P1ZfVBgBK7bDdjNxcbIK8Hgw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/utils": "^6.21.0",
 				"camel-case": "^4.1.2",
-				"eslint-plugin-local": "^1.0.0",
 				"indefinite": "^2.5.1",
 				"pascal-case": "^3.1.2",
 				"pluralize": "^8.0.0",
@@ -3018,68 +4584,6 @@
 			"engines": {
 				"node": ">=20.15",
 				"pnpm": ">=9.6"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/eslintrc": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ajv": "^6.12.4",
-				"debug": "^4.3.2",
-				"espree": "^9.6.0",
-				"globals": "^13.19.0",
-				"ignore": "^5.2.0",
-				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
-				"minimatch": "^3.1.2",
-				"strip-json-comments": "^3.1.1"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/js": {
-			"version": "8.57.1",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@typescript-eslint/scope-manager": {
@@ -3193,9 +4697,25 @@
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/eslint": {
@@ -3205,7 +4725,6 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -3262,7 +4781,6 @@
 			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -3280,19 +4798,17 @@
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -3306,7 +4822,6 @@
 			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
@@ -3325,7 +4840,6 @@
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
@@ -3339,7 +4853,6 @@
 			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.3",
@@ -3353,10 +4866,9 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -3378,41 +4890,22 @@
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/minimatch": {
@@ -3438,7 +4931,6 @@
 			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -3455,7 +4947,6 @@
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -3476,32 +4967,20 @@
 				"typescript": ">=4.2.0"
 			}
 		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/eslint-scope": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -3520,69 +4999,45 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/espree": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.15.0",
+				"acorn": "^8.16.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.2.1"
+				"eslint-visitor-keys": "^5.0.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -3606,7 +5061,6 @@
 			"resolved": "https://registry.npmjs.org/esprima-next/-/esprima-next-5.8.4.tgz",
 			"integrity": "sha512-8nYVZ4ioIH4Msjb/XmhnBdz5WRRBaYqevKa1cv9nGJdCehMbzZCPNEEnqfLCZVetUVrUPEcb5IYyu1GG4hFqgg==",
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -3616,9 +5070,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -3662,9 +5116,9 @@
 			}
 		},
 		"node_modules/eta": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/eta/-/eta-4.0.1.tgz",
-			"integrity": "sha512-0h0oBEsF6qAJU7eu9ztvJoTo8D2PAq/4FvXVIQA1fek3WOTe6KPsVJycekG1+g1N6mfpblkheoGwaUhMtnlH4A==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/eta/-/eta-4.5.0.tgz",
+			"integrity": "sha512-qifAYjuW5AM1eEEIsFnOwB+TGqu6ynU3OKj9WbUTOtUBHFPZqL03XUW34kbp3zm19Ald+U8dEyRXaVsUck+Y1g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3673,6 +5127,23 @@
 			"funding": {
 				"url": "https://github.com/bgub/eta?sponsor=1"
 			}
+		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/execa": {
 			"version": "8.0.1",
@@ -3715,9 +5186,16 @@
 			}
 		},
 		"node_modules/exsolve": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
-			"integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+			"integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3800,9 +5278,9 @@
 			}
 		},
 		"node_modules/fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3822,20 +5300,56 @@
 				"node": ">=16.0.0"
 			}
 		},
+		"node_modules/file-type": {
+			"version": "21.3.3",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.3.tgz",
+			"integrity": "sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
 		"node_modules/filelist": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-			"integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+			"integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"minimatch": "^5.0.1"
 			}
 		},
+		"node_modules/filelist/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/filelist/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
 		"node_modules/filelist/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3875,6 +5389,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/flat": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"bin": {
+				"flat": "cli.js"
+			}
+		},
 		"node_modules/flat-cache": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -3890,18 +5414,38 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/for-each": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
 			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"is-callable": "^1.2.7"
 			},
@@ -3930,18 +5474,41 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/form-data-encoder": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+			"integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/formdata-node": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+			"integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "1.0.0",
+				"web-streams-polyfill": "4.0.0-beta.3"
+			},
+			"engines": {
+				"node": ">= 12.20"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -3949,15 +5516,28 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -3967,7 +5547,6 @@
 			"resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
 			"integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -3977,15 +5556,14 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/get-east-asian-width": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-			"integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4000,7 +5578,6 @@
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
 			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
@@ -4035,7 +5612,6 @@
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
 				"es-object-atoms": "^1.0.0"
@@ -4058,9 +5634,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.12.0.tgz",
-			"integrity": "sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==",
+			"version": "4.13.6",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+			"integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4125,15 +5701,16 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-			"integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+			"integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"foreground-child": "^3.3.1",
 				"jackspeak": "^4.1.1",
-				"minimatch": "^10.0.3",
+				"minimatch": "^10.1.1",
 				"minipass": "^7.1.2",
 				"package-json-from-dist": "^1.0.0",
 				"path-scurry": "^2.0.0"
@@ -4161,30 +5738,30 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/glob/node_modules/minimatch": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-			"integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@isaacs/brace-expansion": "^5.0.0"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/globals": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/globals/node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -4216,7 +5793,6 @@
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -4268,7 +5844,6 @@
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0"
 			},
@@ -4281,7 +5856,6 @@
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -4294,7 +5868,6 @@
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"has-symbols": "^1.0.3"
 			},
@@ -4310,7 +5883,6 @@
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
 			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -4356,10 +5928,49 @@
 				"node": ">=16.17.0"
 			}
 		},
+		"node_modules/humanize-ms": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.0.0"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core": {
+			"version": "5.4.9",
+			"resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.9.tgz",
+			"integrity": "sha512-340fGcZEwUBdxBOPmn8V8fIiFRWF92yFqSFRNLwPQz4h+PS4jcAyd3JGqU6CpFqzUTt+PatVX/jHFwzUTVdmxQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.19.80",
+				"@types/tough-cookie": "^4.0.0",
+				"axios": "^1.13.5",
+				"camelcase": "^6.3.0",
+				"debug": "^4.3.4",
+				"dotenv": "^16.4.5",
+				"extend": "3.0.2",
+				"file-type": "^21.3.2",
+				"form-data": "^4.0.4",
+				"isstream": "0.1.2",
+				"jsonwebtoken": "^9.0.3",
+				"load-esm": "^1.0.3",
+				"mime-types": "2.1.35",
+				"retry-axios": "^2.6.0",
+				"tough-cookie": "^4.1.3"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
 		"node_modules/iconv-lite": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-			"integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4372,6 +5983,27 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
 			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -4437,7 +6069,6 @@
 			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -4447,22 +6078,21 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/inquirer": {
-			"version": "12.9.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.6.tgz",
-			"integrity": "sha512-603xXOgyfxhuis4nfnWaZrMaotNT0Km9XwwBNWUKbIDqeCY89jGr2F9YPEMiNhU6XjIP4VoWISMBFfcc5NgrTw==",
+			"version": "12.11.1",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
+			"integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/ansi": "^1.0.0",
-				"@inquirer/core": "^10.2.2",
-				"@inquirer/prompts": "^7.8.6",
-				"@inquirer/type": "^3.0.8",
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/prompts": "^7.10.1",
+				"@inquirer/type": "^3.0.10",
 				"mute-stream": "^2.0.0",
-				"run-async": "^4.0.5",
+				"run-async": "^4.0.6",
 				"rxjs": "^7.8.2"
 			},
 			"engines": {
@@ -4478,9 +6108,9 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-			"integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4492,7 +6122,6 @@
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
 			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"has-tostringtag": "^1.0.2"
@@ -4508,8 +6137,7 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/is-bun-module": {
 			"version": "2.0.0",
@@ -4526,7 +6154,6 @@
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -4574,7 +6201,6 @@
 			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
 			"integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.4",
 				"generator-function": "^2.0.0",
@@ -4655,7 +6281,6 @@
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
 			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3"
@@ -4665,6 +6290,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-network-error": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+			"integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-number": {
@@ -4683,7 +6321,6 @@
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4693,7 +6330,6 @@
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
 			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"gopd": "^1.2.0",
@@ -4735,7 +6371,6 @@
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
 			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"which-typed-array": "^1.1.16"
 			},
@@ -4779,6 +6414,26 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/isolated-vm": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
+			"integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
+			"hasInstallScript": true,
+			"license": "ISC",
+			"dependencies": {
+				"node-gyp-build": "^4.8.4"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/issue-parser": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
@@ -4797,13 +6452,13 @@
 			}
 		},
 		"node_modules/jackspeak": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+			"integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
+				"@isaacs/cliui": "^9.0.0"
 			},
 			"engines": {
 				"node": "20 || >=22"
@@ -4843,6 +6498,7 @@
 			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
@@ -4852,7 +6508,6 @@
 			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
 			"integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6.0"
 			}
@@ -4861,13 +6516,22 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
 			"integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/js-tiktoken": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.12.tgz",
+			"integrity": "sha512-L7wURW1fH9Qaext0VzaUDpFGVQgjkdE3Dgsy9/+yXyGEpBKnylTd0mU0bfbNkKDlXRb6TEsZkwuflu1B8uQbJQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.5.1"
+			}
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4898,14 +6562,85 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-with-bigint": {
+			"version": "3.5.7",
+			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.7.tgz",
+			"integrity": "sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jsonpointer": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+			"integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/jsonrepair": {
+			"version": "3.13.2",
+			"resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.2.tgz",
+			"integrity": "sha512-Leuly0nbM4R+S5SVJk3VHfw1oxnlEK9KygdZvfUtEtTawNDyzB4qa1xWTmFt1aeoA7sXZkVTRuIixJ8bAvqVUg==",
+			"license": "ISC",
+			"bin": {
+				"jsonrepair": "bin/cli.js"
+			}
+		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jws": "^4.0.1",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
 		"node_modules/jssha": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
 			"integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/keyv": {
@@ -4926,6 +6661,42 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/langsmith": {
+			"version": "0.3.87",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
+			"integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/uuid": "^10.0.0",
+				"chalk": "^4.1.2",
+				"console-table-printer": "^2.12.1",
+				"p-queue": "^6.6.2",
+				"semver": "^7.6.3",
+				"uuid": "^10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/levn": {
@@ -4955,6 +6726,26 @@
 				"url": "https://github.com/sponsors/antonk52"
 			}
 		},
+		"node_modules/load-esm": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
+			"integrity": "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/Borewit"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://buymeacoffee.com/borewit"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=13.2.0"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4972,9 +6763,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.capitalize": {
@@ -4988,6 +6779,34 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5009,6 +6828,13 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5057,11 +6883,10 @@
 			}
 		},
 		"node_modules/luxon": {
-			"version": "3.4.4",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
-			"integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+			"integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -5079,12 +6904,25 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/math-expression-evaluator": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-2.0.7.tgz",
+			"integrity": "sha512-uwliJZ6BPHRq4eiqNWxZBDzKUiS5RIynFFcgchqhBOloVLVBpZpNG8jRYkedLcBvhph8TnRyWEuxPqiQcwIdog==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -5094,7 +6932,6 @@
 			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
 			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"charenc": "0.0.2",
 				"crypt": "0.0.2",
@@ -5137,7 +6974,6 @@
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -5147,7 +6983,6 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"mime-db": "1.52.0"
 			},
@@ -5182,16 +7017,16 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -5208,11 +7043,11 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
@@ -5223,6 +7058,16 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/mustache": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+			"integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mustache": "bin/mustache"
+			}
 		},
 		"node_modules/mute-stream": {
 			"version": "2.0.0",
@@ -5235,29 +7080,47 @@
 			}
 		},
 		"node_modules/n8n-workflow": {
-			"version": "1.113.0",
-			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-1.113.0.tgz",
-			"integrity": "sha512-WiNbm2Us/lSOTioKQZeNdLMGlbOuDMUFVuC0aMVIrQl4YarUmIAyxH7xHkpOoWrahXwbg7PrW27aPkjjAHiEgg==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.13.0.tgz",
+			"integrity": "sha512-fYLyYDlenGlzNvC+i+xsiFSna7gZVbhhTTb215ygL7JVguJhWy7JqW8szhvxkJMqujP0ejlbJYzPfRVxNyllkQ==",
 			"license": "SEE LICENSE IN LICENSE.md",
-			"peer": true,
 			"dependencies": {
-				"@n8n/errors": "^0.5.0",
+				"@n8n/errors": "0.6.0",
+				"@n8n/expression-runtime": "0.5.0",
 				"@n8n/tournament": "1.0.6",
-				"ast-types": "0.15.2",
+				"ast-types": "0.16.1",
 				"callsites": "3.1.0",
 				"esprima-next": "5.8.4",
-				"form-data": "4.0.0",
+				"form-data": "4.0.4",
 				"jmespath": "0.16.0",
 				"js-base64": "3.7.2",
+				"jsonrepair": "3.13.2",
 				"jssha": "3.3.1",
-				"lodash": "4.17.21",
-				"luxon": "3.4.4",
+				"lodash": "4.17.23",
+				"luxon": "3.7.2",
 				"md5": "2.3.0",
 				"recast": "0.22.0",
 				"title-case": "3.0.3",
 				"transliteration": "2.3.5",
+				"uuid": "10.0.0",
 				"xml2js": "0.6.2",
 				"zod": "3.25.67"
+			}
+		},
+		"node_modules/n8n-workflow/node_modules/form-data": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/napi-postinstall": {
@@ -5340,12 +7203,65 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/node-fetch-native": {
 			"version": "1.6.7",
 			"resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
 			"integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"license": "MIT",
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
 		},
 		"node_modules/npm-run-path": {
 			"version": "5.3.0",
@@ -5377,31 +7293,35 @@
 			}
 		},
 		"node_modules/nypm": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
-			"integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+			"integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"citty": "^0.1.6",
-				"consola": "^3.4.2",
+				"citty": "^0.2.0",
 				"pathe": "^2.0.3",
-				"pkg-types": "^2.3.0",
-				"tinyexec": "^1.0.1"
+				"tinyexec": "^1.0.2"
 			},
 			"bin": {
 				"nypm": "dist/cli.mjs"
 			},
 			"engines": {
-				"node": "^14.16.0 || >=16.10.0"
+				"node": ">=18"
 			}
+		},
+		"node_modules/nypm/node_modules/citty": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
+			"integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/object-is": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
 			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"define-properties": "^1.2.1"
@@ -5418,7 +7338,6 @@
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -5428,7 +7347,6 @@
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
 			"integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.3",
@@ -5457,7 +7375,6 @@
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -5496,6 +7413,45 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/openai": {
+			"version": "4.104.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+			"integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "^18.11.18",
+				"@types/node-fetch": "^2.6.4",
+				"abort-controller": "^3.0.0",
+				"agentkeepalive": "^4.2.1",
+				"form-data-encoder": "1.7.2",
+				"formdata-node": "^4.3.2",
+				"node-fetch": "^2.6.7"
+			},
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.23.8"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openapi-types": {
+			"version": "12.1.3",
+			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+			"integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
@@ -5553,9 +7509,9 @@
 			}
 		},
 		"node_modules/ora/node_modules/cli-spinners": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.3.0.tgz",
-			"integrity": "sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+			"integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5566,14 +7522,14 @@
 			}
 		},
 		"node_modules/ora/node_modules/string-width": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-			"integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+			"integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"get-east-asian-width": "^1.3.0",
-				"strip-ansi": "^7.1.0"
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
 			},
 			"engines": {
 				"node": ">=20"
@@ -5597,6 +7553,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/p-limit": {
@@ -5629,6 +7595,52 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-queue": {
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+			"integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eventemitter3": "^4.0.4",
+				"p-timeout": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+			"integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-network-error": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-timeout": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-finally": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/pac-proxy-agent": {
@@ -5743,7 +7755,6 @@
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5759,9 +7770,9 @@
 			}
 		},
 		"node_modules/path-scurry": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-			"integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -5769,18 +7780,18 @@
 				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/path-scurry/node_modules/lru-cache": {
-			"version": "11.2.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-			"integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+			"version": "11.2.7",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+			"integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
 			}
@@ -5803,9 +7814,9 @@
 			"license": "MIT"
 		},
 		"node_modules/perfect-debounce": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
-			"integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+			"integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5841,6 +7852,38 @@
 				"pathe": "^2.0.3"
 			}
 		},
+		"node_modules/playwright": {
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.58.2"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/pluralize": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -5856,7 +7899,6 @@
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
 			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -5872,9 +7914,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5935,6 +7977,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/psl": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/lupomontero"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5944,6 +7999,13 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -5978,13 +8040,13 @@
 			}
 		},
 		"node_modules/readdirp": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 14.18.0"
+				"node": ">= 20.19.0"
 			},
 			"funding": {
 				"type": "individual",
@@ -5996,7 +8058,6 @@
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.22.0.tgz",
 			"integrity": "sha512-5AAx+mujtXijsEavc5lWXBPQqrM4+Dl5qNH96N2aNeuJFUzpiiToKPsxQD/zAIJHspz7zz0maX0PCtCTFVlixQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"assert": "^2.0.0",
 				"ast-types": "0.15.2",
@@ -6008,10 +8069,29 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/recast/node_modules/ast-types": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
+			"integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/reflect-metadata": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+			"integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/release-it": {
-			"version": "19.0.5",
-			"resolved": "https://registry.npmjs.org/release-it/-/release-it-19.0.5.tgz",
-			"integrity": "sha512-bYlUKC0TQroBKi8jQUeoxLHql4d9Fx/2EQLHPKUobXTNSiTS2WY8vlgdHZRhRjVEMyAWwyadJVKfFZnRJuRn4Q==",
+			"version": "19.2.4",
+			"resolved": "https://registry.npmjs.org/release-it/-/release-it-19.2.4.tgz",
+			"integrity": "sha512-BwaJwQYUIIAKuDYvpqQTSoy0U7zIy6cHyEjih/aNaFICphGahia4cjDANuFXb7gVZ51hIK9W0io6fjNQWXqICg==",
 			"dev": true,
 			"funding": [
 				{
@@ -6026,25 +8106,25 @@
 			"license": "MIT",
 			"dependencies": {
 				"@nodeutils/defaults-deep": "1.1.0",
-				"@octokit/rest": "22.0.0",
+				"@octokit/rest": "22.0.1",
 				"@phun-ky/typeof": "2.0.3",
 				"async-retry": "1.3.3",
-				"c12": "3.3.0",
-				"ci-info": "^4.3.0",
-				"eta": "4.0.1",
+				"c12": "3.3.3",
+				"ci-info": "^4.3.1",
+				"eta": "4.5.0",
 				"git-url-parse": "16.1.0",
-				"inquirer": "12.9.6",
+				"inquirer": "12.11.1",
 				"issue-parser": "7.0.1",
 				"lodash.merge": "4.6.2",
-				"mime-types": "3.0.1",
+				"mime-types": "3.0.2",
 				"new-github-release-url": "2.0.0",
 				"open": "10.2.0",
 				"ora": "9.0.0",
 				"os-name": "6.1.0",
 				"proxy-agent": "6.5.0",
-				"semver": "7.7.2",
+				"semver": "7.7.3",
 				"tinyglobby": "0.2.15",
-				"undici": "6.21.3",
+				"undici": "6.23.0",
 				"url-join": "5.0.0",
 				"wildcard-match": "5.1.4",
 				"yargs-parser": "21.1.1"
@@ -6067,22 +8147,26 @@
 			}
 		},
 		"node_modules/release-it/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mime-db": "^1.54.0"
 			},
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/release-it/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -6092,15 +8176,31 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/release-it/node_modules/undici": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+			"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
@@ -6147,6 +8247,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
+			}
+		},
+		"node_modules/retry-axios": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
+			"integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.7.0"
+			},
+			"peerDependencies": {
+				"axios": "*"
 			}
 		},
 		"node_modules/reusify": {
@@ -6237,12 +8350,32 @@
 				"tslib": "^2.1.0"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/safe-regex-test": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
 			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
@@ -6263,16 +8396,18 @@
 			"license": "MIT"
 		},
 		"node_modules/sax": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-			"license": "ISC",
-			"peer": true
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -6299,7 +8434,6 @@
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -6347,6 +8481,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
+		},
+		"node_modules/simple-wcswidth": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+			"integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
@@ -6452,45 +8593,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/string-width-cjs": {
-			"name": "string-width",
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/string-width/node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -6513,43 +8615,19 @@
 			}
 		},
 		"node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/strip-final-newline": {
@@ -6578,6 +8656,23 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/strtok3": {
+			"version": "10.3.4",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -6599,15 +8694,17 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
-			"integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+			"integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
@@ -6650,6 +8747,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -6666,6 +8764,26 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/tmp": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/tmp-promise": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+			"integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tmp": "^0.2.0"
+			}
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6679,12 +8797,53 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/token-types": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/transliteration": {
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/transliteration/-/transliteration-2.3.5.tgz",
 			"integrity": "sha512-HAGI4Lq4Q9dZ3Utu2phaWgtm3vB6PkLUFqWAScg/UW+1eZ/Tg6Exo4oC0/3VUol/w4BlefLhUUSVBr/9/ZGQOw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"yargs": "^17.5.1"
 			},
@@ -6697,9 +8856,9 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-			"integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6710,14 +8869,58 @@
 			}
 		},
 		"node_modules/ts-morph": {
-			"version": "26.0.0",
-			"resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-26.0.0.tgz",
-			"integrity": "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==",
+			"version": "27.0.2",
+			"resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
+			"integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ts-morph/common": "~0.27.0",
+				"@ts-morph/common": "~0.28.1",
 				"code-block-writer": "^13.0.3"
+			}
+		},
+		"node_modules/ts-node": {
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.50",
+				"@swc/wasm": ">=1.2.50",
+				"@types/node": "*",
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/wasm": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/tslib": {
@@ -6753,11 +8956,12 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -6767,16 +8971,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.46.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.1.tgz",
-			"integrity": "sha512-VHgijW803JafdSsDO8I761r3SHrgk4T00IdyQ+/UsthtgPRsBWQLqoSxOolxTpxRKi1kGXK0bSz4CoAc9ObqJA==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
+			"integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.46.1",
-				"@typescript-eslint/parser": "8.46.1",
-				"@typescript-eslint/typescript-estree": "8.46.1",
-				"@typescript-eslint/utils": "8.46.1"
+				"@typescript-eslint/eslint-plugin": "8.57.1",
+				"@typescript-eslint/parser": "8.57.1",
+				"@typescript-eslint/typescript-estree": "8.57.1",
+				"@typescript-eslint/utils": "8.57.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6786,7 +8990,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
@@ -6804,15 +9008,35 @@
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/undici": {
-			"version": "6.21.3",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-			"integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+			"integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/universal-user-agent": {
 			"version": "7.0.3",
@@ -6820,6 +9044,16 @@
 			"integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
 		},
 		"node_modules/unrs-resolver": {
 			"version": "1.11.1",
@@ -6886,18 +9120,76 @@
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
+		},
 		"node_modules/util": {
 			"version": "0.12.5",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
 			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"is-arguments": "^1.0.4",
 				"is-generator-function": "^1.0.7",
 				"is-typed-array": "^1.1.3",
 				"which-typed-array": "^1.1.2"
+			}
+		},
+		"node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "4.0.0-beta.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+			"integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -6917,11 +9209,10 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.19",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.8",
@@ -7008,48 +9299,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/wrap-ansi/node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -7057,6 +9306,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/wrap-ansi/node_modules/strip-ansi": {
@@ -7076,8 +9340,30 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
+		},
+		"node_modules/ws": {
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/wsl-utils": {
 			"version": "0.1.0",
@@ -7096,9 +9382,9 @@
 			}
 		},
 		"node_modules/wsl-utils/node_modules/is-wsl": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7116,7 +9402,6 @@
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
 			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"
@@ -7130,7 +9415,6 @@
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
 			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -7140,9 +9424,24 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yargs": {
@@ -7150,7 +9449,6 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -7171,6 +9469,16 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/yocto-queue": {
@@ -7220,6 +9528,17 @@
 			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.23.3",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
+			"integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"zod": "^3.23.3"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
 	},
 	"devDependencies": {
 		"@n8n/node-cli": "*",
-		"eslint": "10.0.3",
+		"eslint": "9.39.4",
 		"prettier": "3.8.1",
-		"release-it": "^19.2.4",
+		"release-it": "19.2.4",
 		"typescript": "5.9.3"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
 	},
 	"devDependencies": {
 		"@n8n/node-cli": "*",
-		"eslint": "9.32.0",
-		"prettier": "3.6.2",
-		"release-it": "^19.0.4",
-		"typescript": "5.9.2"
+		"eslint": "10.0.3",
+		"prettier": "3.8.1",
+		"release-it": "^19.2.4",
+		"typescript": "5.9.3"
 	},
 	"peerDependencies": {
 		"n8n-workflow": "*"


### PR DESCRIPTION
Linear ticket: https://linear.app/n8n/issue/CE-577/add-example-gh-action-to-starter-template
Sibling PR: https://github.com/n8n-io/n8n/pull/27288

## Summary

- Adds `.github/workflows/publish.yml` — publishes to npm on every version tag push with a provenance attestation, satisfying n8n's requirement for community nodes starting May 1, 2026. Supports both OIDC Trusted Publishing (no secrets) and a fallback `NPM_TOKEN`. Extensively documented inline.
- Updates `.github/workflows/ci.yml` — switches to `lts/*`, adds `cache: 'npm'` and a `concurrency` group to cancel redundant runs on new pushes.
- Updates `README.md` (step 10) — replaces bare `npm publish` with documentation for the automated workflow, including the one-time OIDC setup and `npm run release` as the release command.
- Bumps dev dependencies: `eslint` 9.32 → 9.39.4, `prettier` 3.6 → 3.8.1, `release-it` 19.0 → 19.2.4, `typescript` 5.9.2 → 5.9.3.

## Notes

- Updated dependencies to fulfill `@n8n/node-cli ≥ 0.23.0` requirement (documented in the workflow).