### PR TITLE
chore: update lint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@n8n/node-cli": "*",
+				"@n8n/node-cli": "^0.23.1",
 				"eslint": "9.39.4",
-				"prettier": "3.8.1",
+				"prettier": "3.8.3",
 				"release-it": "19.2.4",
 				"typescript": "5.9.3"
 			},
@@ -47,9 +47,9 @@
 			}
 		},
 		"node_modules/@browserbasehq/sdk": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.9.0.tgz",
-			"integrity": "sha512-Xzm1+6suzQypXjley4Phqer++pjnYyST6S7CArUn3kWyGA8aruXjAV5wkmqE21lgXo9K3/OQJvCu48bKEZFNDQ==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.10.0.tgz",
+			"integrity": "sha512-pOL4yW8P8AI2+N5y6zEP6XXKqIXtYyKunr1JXppqQDOyKLxxvZEDqQCHJXWUzqgx3R1tGWpn7m9AjXN7MeYInA==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "^18.11.18",
@@ -82,13 +82,13 @@
 			}
 		},
 		"node_modules/@browserbasehq/stagehand/node_modules/zod-to-json-schema": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-			"integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
 			"dev": true,
 			"license": "ISC",
 			"peerDependencies": {
-				"zod": "^3.25 || ^4"
+				"zod": "^3.25.28 || ^4"
 			}
 		},
 		"node_modules/@cfworker/json-schema": {
@@ -484,9 +484,9 @@
 			}
 		},
 		"node_modules/@ibm-cloud/watsonx-ai": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.10.tgz",
-			"integrity": "sha512-+ckgkR/qLQSG5hmVrD3OywWGEmY8Vgo3WR3T0jGJxcO9w89gPwgQENn3qFnhF0YlILGEl4zNPuTYYDj1MtNSng==",
+			"version": "1.7.11",
+			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.11.tgz",
+			"integrity": "sha512-sBMj/YhV5qvJdBpvgutmX6vLUUnSwvhFaJk7r3hiMh5aB7BQWQ+5zyzvSPLywOwTWZbgy4v8jxTUhR6jb+kguw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -494,7 +494,7 @@
 				"@types/node": "^18.0.0",
 				"extend": "3.0.2",
 				"form-data": "^4.0.4",
-				"ibm-cloud-sdk-core": "^5.4.5",
+				"ibm-cloud-sdk-core": "^5.4.9",
 				"ts-node": "^10.9.2"
 			},
 			"engines": {
@@ -1548,9 +1548,9 @@
 			}
 		},
 		"node_modules/@langchain/community/node_modules/@langchain/openai/node_modules/openai": {
-			"version": "6.32.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.32.0.tgz",
-			"integrity": "sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==",
+			"version": "6.34.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+			"integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -1569,34 +1569,16 @@
 				}
 			}
 		},
-		"node_modules/@langchain/community/node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
 		"node_modules/@langchain/community/node_modules/langsmith": {
-			"version": "0.5.11",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.11.tgz",
-			"integrity": "sha512-Yio502Ow2vbVt16P1sybNMNpMsr5BMqoeonoi4flrcDsP55No/aCe2zydtBNOv0+kjKQw4WSKAzTsNwenDeD5w==",
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.21.tgz",
+			"integrity": "sha512-l140hzgqo91T/QKDXLEfRnnxahuwVEVohr9zqpy3BaGDeBdrPiJuNJ2TBhPZxNXNCl68IkVcn555FD3jp5peyw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@types/uuid": "^10.0.0",
-				"chalk": "^5.6.2",
-				"console-table-printer": "^2.12.1",
-				"p-queue": "^6.6.2",
-				"semver": "^7.6.3",
-				"uuid": "^10.0.0"
+				"p-queue": "6.6.2",
+				"uuid": "10.0.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "*",
@@ -1629,14 +1611,15 @@
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@langchain/core": {
-			"version": "1.1.34",
-			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.34.tgz",
-			"integrity": "sha512-IDlZES5Vexo5meLQRCGkAU7NM0tPGPfPP5wcUzBd7Ot+JoFBmSXutC4gGzvZod5AKRVn3I0Qy5k8vkTraY21jA==",
+			"version": "1.1.40",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.40.tgz",
+			"integrity": "sha512-RJ41GQEMxr9ZEZNoIiPgW0+v9nAY6FEZGlk+MjBghr2GR8He50abLam0XCe1aqUJjuKbqt2lUD6M+6SZ+2NIJg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1657,32 +1640,15 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/@langchain/core/node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
 		"node_modules/@langchain/core/node_modules/langsmith": {
-			"version": "0.5.11",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.11.tgz",
-			"integrity": "sha512-Yio502Ow2vbVt16P1sybNMNpMsr5BMqoeonoi4flrcDsP55No/aCe2zydtBNOv0+kjKQw4WSKAzTsNwenDeD5w==",
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.21.tgz",
+			"integrity": "sha512-l140hzgqo91T/QKDXLEfRnnxahuwVEVohr9zqpy3BaGDeBdrPiJuNJ2TBhPZxNXNCl68IkVcn555FD3jp5peyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/uuid": "^10.0.0",
-				"chalk": "^5.6.2",
-				"console-table-printer": "^2.12.1",
-				"p-queue": "^6.6.2",
-				"semver": "^7.6.3",
-				"uuid": "^10.0.0"
+				"p-queue": "6.6.2",
+				"uuid": "10.0.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "*",
@@ -1747,6 +1713,32 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
+		"node_modules/@langchain/langgraph": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.9.tgz",
+			"integrity": "sha512-3c7BtGycHC2v9p6w/Hv8L7kEl1YnZYOQTDJtmAp3knk6JOedO7d2bYP3y0SRyhv5orUEGf/KGvx8ZsB/ideP7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@langchain/langgraph-checkpoint": "^1.0.1",
+				"@langchain/langgraph-sdk": "~1.8.9",
+				"@standard-schema/spec": "1.1.0",
+				"uuid": "^10.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.1.40",
+				"zod": "^3.25.32 || ^4.2.0",
+				"zod-to-json-schema": "^3.x"
+			},
+			"peerDependenciesMeta": {
+				"zod-to-json-schema": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@langchain/langgraph-checkpoint": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
@@ -1761,6 +1753,94 @@
 			},
 			"peerDependencies": {
 				"@langchain/core": "^1.0.1"
+			}
+		},
+		"node_modules/@langchain/langgraph-sdk": {
+			"version": "1.8.9",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.9.tgz",
+			"integrity": "sha512-vpz90auS4iFTNy2X/CFexOEoeFSvaK+MyI7iSmzYs9gGcfzwRjWUJ4MWsuc5ZNRecLStwho0PExVXRgGOXtcRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15",
+				"p-queue": "^9.0.1",
+				"p-retry": "^7.1.1",
+				"uuid": "^13.0.0"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.1.16",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19",
+				"svelte": "^4.0.0 || ^5.0.0",
+				"vue": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@langchain/core": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
+			"integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eventemitter3": "^5.0.1",
+				"p-timeout": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+			"integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/@langchain/openai": {
@@ -1782,9 +1862,9 @@
 			}
 		},
 		"node_modules/@langchain/openai/node_modules/openai": {
-			"version": "6.32.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.32.0.tgz",
-			"integrity": "sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==",
+			"version": "6.34.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+			"integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -1840,32 +1920,32 @@
 			}
 		},
 		"node_modules/@n8n/ai-node-sdk": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.4.0.tgz",
-			"integrity": "sha512-9+t69B+EQeq1yC3qWFysGEyrWXWog2XpIOXoqFnfV5ZQKd+IUSEgTKVpb13UoMcmM1oRaLcZ4onvcORh1z8FvQ==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.4.1.tgz",
+			"integrity": "sha512-ntGncJGZJ37B2s8dGbMLEo9+KW2vAHLn+DhTDHPUYnNut/p7V2gQzzC4ltDLkefChcaMqL0P8l79ntCnJ2pIaA==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@n8n/ai-utilities": "0.6.0"
+				"@n8n/ai-utilities": "0.7.1"
 			}
 		},
 		"node_modules/@n8n/ai-utilities": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.6.0.tgz",
-			"integrity": "sha512-QZUTViZchpHFdzlhM14P7s+tnjoPqup+Dri3FRWpbXGIRZ6no5htXuDZa2EaHxfJzJagT30Em3n14Te3x3y1iA==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.7.1.tgz",
+			"integrity": "sha512-+VDOInOIh2M3W5o1O77oeip1NEpmhcR5GcEHaJpa9Cpw5B0pgU848WGmK3NDPwCZniOAuRFEqcvBu1W/+S5qLw==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@langchain/classic": "1.0.5",
 				"@langchain/community": "1.1.14",
-				"@langchain/core": "1.1.8",
+				"@langchain/core": "1.1.31",
 				"@langchain/openai": "1.1.3",
 				"@langchain/textsplitters": "1.0.1",
-				"@n8n/config": "2.11.0",
+				"@n8n/config": "2.12.1",
 				"@n8n/typescript-config": "1.3.0",
 				"https-proxy-agent": "7.0.6",
 				"js-tiktoken": "1.0.12",
-				"langchain": "1.2.3",
+				"langchain": "1.2.30",
 				"proxy-from-env": "^1.1.0",
 				"tmp-promise": "3.0.3",
 				"undici": "^6.21.0",
@@ -1877,21 +1957,22 @@
 			}
 		},
 		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.8.tgz",
-			"integrity": "sha512-kIUidOgc0ZdyXo4Ahn9Zas+OayqOfk4ZoKPi7XaDipNSWSApc2+QK5BVcjvwtzxstsNOrmXJiJWEN6WPF/MvAw==",
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.31.tgz",
+			"integrity": "sha512-FxsgIUONjKaRpjx59sISgmb0OMCbAetPGyhzjGa2kX0y1f8LZ5xm9VB2db7W9HYWyLvzRWcMA51Uu4OSTJmtZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cfworker/json-schema": "^4.0.2",
+				"@standard-schema/spec": "^1.1.0",
 				"ansi-styles": "^5.0.0",
 				"camelcase": "6",
 				"decamelize": "1.2.0",
 				"js-tiktoken": "^1.0.12",
-				"langsmith": ">=0.4.0 <1.0.0",
+				"langsmith": ">=0.5.0 <1.0.0",
 				"mustache": "^4.2.0",
 				"p-queue": "^6.6.2",
-				"uuid": "^10.0.0",
+				"uuid": "^11.1.0",
 				"zod": "^3.25.76 || ^4"
 			},
 			"engines": {
@@ -1899,18 +1980,14 @@
 			}
 		},
 		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/langsmith": {
-			"version": "0.5.11",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.11.tgz",
-			"integrity": "sha512-Yio502Ow2vbVt16P1sybNMNpMsr5BMqoeonoi4flrcDsP55No/aCe2zydtBNOv0+kjKQw4WSKAzTsNwenDeD5w==",
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.21.tgz",
+			"integrity": "sha512-l140hzgqo91T/QKDXLEfRnnxahuwVEVohr9zqpy3BaGDeBdrPiJuNJ2TBhPZxNXNCl68IkVcn555FD3jp5peyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/uuid": "^10.0.0",
-				"chalk": "^5.6.2",
-				"console-table-printer": "^2.12.1",
-				"p-queue": "^6.6.2",
-				"semver": "^7.6.3",
-				"uuid": "^10.0.0"
+				"p-queue": "6.6.2",
+				"uuid": "10.0.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "*",
@@ -1935,6 +2012,34 @@
 				"ws": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/langsmith/node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/zod": {
@@ -1947,211 +2052,10 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
-		"node_modules/@n8n/ai-utilities/node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/eventemitter3": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/langchain": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/langchain/-/langchain-1.2.3.tgz",
-			"integrity": "sha512-3k986xJuqg4az53JxV5LnGlOzIXF1d9Kq6Y9s7XjitvzhpsbFuTDV5/kiF4cx3pkNGyw0mUXC4tLz9RxucO0hw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@langchain/langgraph": "^1.0.0",
-				"@langchain/langgraph-checkpoint": "^1.0.0",
-				"langsmith": ">=0.4.0 <1.0.0",
-				"uuid": "^10.0.0",
-				"zod": "^3.25.76 || ^4"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"peerDependencies": {
-				"@langchain/core": "1.1.8"
-			}
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/@langchain/langgraph": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.3.tgz",
-			"integrity": "sha512-wvc7cQ4t6aLmI3PtVvvpN7VTqEmQunrlVnuR6t7z/1l98bj6TnQg8uS+NiJ+gF2TkVC5YXkfqY8Z4EpdD6FlcQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@langchain/langgraph-checkpoint": "^1.0.1",
-				"@langchain/langgraph-sdk": "~1.7.3",
-				"@standard-schema/spec": "1.1.0",
-				"uuid": "^10.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@langchain/core": "^1.1.16",
-				"zod": "^3.25.32 || ^4.2.0",
-				"zod-to-json-schema": "^3.x"
-			},
-			"peerDependenciesMeta": {
-				"zod-to-json-schema": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.7.4.tgz",
-			"integrity": "sha512-SuQyFvL9Q/eBJdSAHLaM1mmfKoh5JAmRF4PdIokX9pyVYBvJqUpvsOcUYtkC3zniHOh/65y1eqvojt/WgPvN8Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/json-schema": "^7.0.15",
-				"p-queue": "^9.0.1",
-				"p-retry": "^7.1.1",
-				"uuid": "^13.0.0"
-			},
-			"peerDependencies": {
-				"@angular/core": "^18.0.0 || ^19.0.0 || ^20.0.0",
-				"@langchain/core": "^1.1.16",
-				"react": "^18 || ^19",
-				"react-dom": "^18 || ^19",
-				"svelte": "^4.0.0 || ^5.0.0",
-				"vue": "^3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@angular/core": {
-					"optional": true
-				},
-				"@langchain/core": {
-					"optional": true
-				},
-				"react": {
-					"optional": true
-				},
-				"react-dom": {
-					"optional": true
-				},
-				"svelte": {
-					"optional": true
-				},
-				"vue": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/@langchain/langgraph/node_modules/p-queue": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
-			"integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"eventemitter3": "^5.0.1",
-				"p-timeout": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/langsmith": {
-			"version": "0.5.11",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.11.tgz",
-			"integrity": "sha512-Yio502Ow2vbVt16P1sybNMNpMsr5BMqoeonoi4flrcDsP55No/aCe2zydtBNOv0+kjKQw4WSKAzTsNwenDeD5w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/uuid": "^10.0.0",
-				"chalk": "^5.6.2",
-				"console-table-printer": "^2.12.1",
-				"p-queue": "^6.6.2",
-				"semver": "^7.6.3",
-				"uuid": "^10.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "*",
-				"@opentelemetry/exporter-trace-otlp-proto": "*",
-				"@opentelemetry/sdk-trace-base": "*",
-				"openai": "*",
-				"ws": ">=7"
-			},
-			"peerDependenciesMeta": {
-				"@opentelemetry/api": {
-					"optional": true
-				},
-				"@opentelemetry/exporter-trace-otlp-proto": {
-					"optional": true
-				},
-				"@opentelemetry/sdk-trace-base": {
-					"optional": true
-				},
-				"openai": {
-					"optional": true
-				},
-				"ws": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/zod": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/@n8n/ai-utilities/node_modules/p-timeout": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
-			"integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@n8n/config": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.11.0.tgz",
-			"integrity": "sha512-GdtJSLTHWpJp++fxiEar7vV3C2mKLAwNA1iurqW7DHizUVuRfGVrjTIAkR7VCvEDDioBpRnMGC6dK2hxdXphbQ==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.12.1.tgz",
+			"integrity": "sha512-rgNrFJvlheRT5rH8KPL589Xcc6B4gtcSRcFuEPuNVeJ1f0XLliKWf9M3ui120e4jtQ9AhRCVGwmIaGN538WrHw==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
@@ -2211,14 +2115,14 @@
 			}
 		},
 		"node_modules/@n8n/node-cli": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.23.0.tgz",
-			"integrity": "sha512-O77A2BI5QC6W8nxDavDIWBvBUlAOEzZ0yuuXVs3vTduaOHMRAZaS0JH38KSKaFTOrOHpqHG8j2LukHsVRJZC0A==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.23.1.tgz",
+			"integrity": "sha512-bl5qL92Ymjl4+nkk4D57007W/+XbBHnuHlMiwMjKR68NQeolCYNqKwXlmAsAgEauZTWe0Rqueybr90FY2rML7w==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@clack/prompts": "^0.11.0",
-				"@n8n/ai-node-sdk": "0.4.0",
+				"@n8n/ai-node-sdk": "0.4.1",
 				"@n8n/eslint-plugin-community-nodes": "0.9.0",
 				"@oclif/core": "^4.5.2",
 				"change-case": "^5.4.4",
@@ -2596,14 +2500,14 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.58.2"
+				"playwright": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -2781,7 +2685,8 @@
 			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
 			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.57.1",
@@ -3533,16 +3438,25 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.6",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-			"integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"follow-redirects": "^1.15.11",
 				"form-data": "^4.0.5",
-				"proxy-from-env": "^1.1.0"
+				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/axios/node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -4055,6 +3969,7 @@
 			"integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"simple-wcswidth": "^1.1.2"
 			}
@@ -4465,6 +4380,7 @@
 			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -5404,9 +5320,9 @@
 			}
 		},
 		"node_modules/file-type": {
-			"version": "21.3.3",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.3.tgz",
-			"integrity": "sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg==",
+			"version": "21.3.4",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5524,9 +5440,9 @@
 			"license": "ISC"
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.11",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"dev": true,
 			"funding": [
 				{
@@ -6042,9 +5958,9 @@
 			}
 		},
 		"node_modules/ibm-cloud-sdk-core": {
-			"version": "5.4.9",
-			"resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.9.tgz",
-			"integrity": "sha512-340fGcZEwUBdxBOPmn8V8fIiFRWF92yFqSFRNLwPQz4h+PS4jcAyd3JGqU6CpFqzUTt+PatVX/jHFwzUTVdmxQ==",
+			"version": "5.4.11",
+			"resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.11.tgz",
+			"integrity": "sha512-UYm6i3OCcQ1sBOVIJh0gcwCNltiGCf7QBCPaDtqCXuHIPbn8m9sKqVBqfrgFuQpenAak/Yv/450Vw+tC59XVIQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -6052,7 +5968,7 @@
 				"@types/debug": "^4.1.12",
 				"@types/node": "^18.19.80",
 				"@types/tough-cookie": "^4.0.0",
-				"axios": "^1.13.5",
+				"axios": "1.15.0",
 				"camelcase": "^6.3.0",
 				"debug": "^4.3.4",
 				"dotenv": "^16.4.5",
@@ -6765,6 +6681,99 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/langchain": {
+			"version": "1.2.30",
+			"resolved": "https://registry.npmjs.org/langchain/-/langchain-1.2.30.tgz",
+			"integrity": "sha512-Ofsk7LTGvIkyy3uesv7hpyerpTghdjNpYFJfIxJRGGLjd+4JgTVkT/Ax6Cjg0F6doEuO7VRID0NK2QwmT3A/bg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@langchain/langgraph": "^1.1.2",
+				"@langchain/langgraph-checkpoint": "^1.0.0",
+				"langsmith": ">=0.5.0 <1.0.0",
+				"uuid": "^11.1.0",
+				"zod": "^3.25.76 || ^4"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@langchain/core": "^1.1.31"
+			}
+		},
+		"node_modules/langchain/node_modules/langsmith": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.21.tgz",
+			"integrity": "sha512-l140hzgqo91T/QKDXLEfRnnxahuwVEVohr9zqpy3BaGDeBdrPiJuNJ2TBhPZxNXNCl68IkVcn555FD3jp5peyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-queue": "6.6.2",
+				"uuid": "10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*",
+				"ws": ">=7"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/langchain/node_modules/langsmith/node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/langchain/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
+		"node_modules/langchain/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/langsmith": {
@@ -7957,13 +7966,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.58.2"
+				"playwright-core": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -7976,9 +7985,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -8018,9 +8027,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -8591,7 +8600,8 @@
 			"resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
 			"integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
@@ -8761,9 +8771,9 @@
 			}
 		},
 		"node_modules/strtok3": {
-			"version": "10.3.4",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9126,9 +9136,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-			"integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+			"integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9447,11 +9457,12 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -9532,9 +9543,9 @@
 			}
 		},
 		"node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "*",
-				"eslint": "9.39.4",
+				"eslint": "10.0.3",
 				"prettier": "3.8.1",
-				"release-it": "19.2.4",
+				"release-it": "^19.2.4",
 				"typescript": "5.9.3"
 			},
 			"peerDependencies": {
@@ -198,75 +198,44 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.21.2",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+			"version": "0.23.3",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+			"integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^2.1.7",
+				"@eslint/object-schema": "^3.0.3",
 				"debug": "^4.3.1",
-				"minimatch": "^3.1.5"
+				"minimatch": "^10.2.4"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/@eslint/config-array/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/@eslint/config-array/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+			"integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.17.0"
+				"@eslint/core": "^1.1.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+			"integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -353,27 +322,27 @@
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+			"integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+			"integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.17.0",
+				"@eslint/core": "^1.1.1",
 				"levn": "^0.4.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@humanfs/core": {
@@ -1629,6 +1598,7 @@
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -1882,6 +1852,7 @@
 			"integrity": "sha512-kIUidOgc0ZdyXo4Ahn9Zas+OayqOfk4ZoKPi7XaDipNSWSApc2+QK5BVcjvwtzxstsNOrmXJiJWEN6WPF/MvAw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cfworker/json-schema": "^4.0.2",
 				"ansi-styles": "^5.0.0",
@@ -2712,6 +2683,13 @@
 				"@types/ms": "*"
 			}
 		},
+		"node_modules/@types/esrecurse": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2978,6 +2956,7 @@
 			"integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
 				"@typescript-eslint/scope-manager": "8.57.1",
@@ -4460,33 +4439,31 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.4",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
+			"integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
-				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.2",
-				"@eslint/config-helpers": "^0.4.2",
-				"@eslint/core": "^0.17.0",
-				"@eslint/eslintrc": "^3.3.5",
-				"@eslint/js": "9.39.4",
-				"@eslint/plugin-kit": "^0.4.1",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@eslint/config-array": "^0.23.3",
+				"@eslint/config-helpers": "^0.5.2",
+				"@eslint/core": "^1.1.1",
+				"@eslint/plugin-kit": "^0.6.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
 				"ajv": "^6.14.0",
-				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^8.4.0",
-				"eslint-visitor-keys": "^4.2.1",
-				"espree": "^10.4.0",
-				"esquery": "^1.5.0",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"espree": "^11.1.1",
+				"esquery": "^1.7.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^8.0.0",
@@ -4496,8 +4473,7 @@
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.5",
+				"minimatch": "^10.2.4",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -4505,7 +4481,7 @@
 				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://eslint.org/donate"
@@ -4992,17 +4968,19 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -5021,126 +4999,45 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/@eslint/eslintrc": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ajv": "^6.14.0",
-				"debug": "^4.3.2",
-				"espree": "^10.0.1",
-				"globals": "^14.0.0",
-				"ignore": "^5.2.0",
-				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.1",
-				"minimatch": "^3.1.5",
-				"strip-json-comments": "^3.1.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint/node_modules/@eslint/js": {
-			"version": "9.39.4",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://eslint.org/donate"
-			}
-		},
-		"node_modules/eslint/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/globals": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/espree": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.15.0",
+				"acorn": "^8.16.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.2.1"
+				"eslint-visitor-keys": "^5.0.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -6114,7 +6011,6 @@
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -9452,6 +9348,7 @@
 			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "*",
-				"eslint": "10.0.3",
+				"eslint": "9.39.4",
 				"prettier": "3.8.1",
-				"release-it": "^19.2.4",
+				"release-it": "19.2.4",
 				"typescript": "5.9.3"
 			},
 			"peerDependencies": {
@@ -198,44 +198,75 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.23.3",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-			"integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^3.0.3",
+				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
-				"minimatch": "^10.2.4"
+				"minimatch": "^3.1.5"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-			"integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.1"
+				"@eslint/core": "^0.17.0"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-			"integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -322,27 +353,27 @@
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-			"integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-			"integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.1",
+				"@eslint/core": "^0.17.0",
 				"levn": "^0.4.1"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@humanfs/core": {
@@ -1598,7 +1629,6 @@
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -1852,7 +1882,6 @@
 			"integrity": "sha512-kIUidOgc0ZdyXo4Ahn9Zas+OayqOfk4ZoKPi7XaDipNSWSApc2+QK5BVcjvwtzxstsNOrmXJiJWEN6WPF/MvAw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@cfworker/json-schema": "^4.0.2",
 				"ansi-styles": "^5.0.0",
@@ -2683,13 +2712,6 @@
 				"@types/ms": "*"
 			}
 		},
-		"node_modules/@types/esrecurse": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2956,7 +2978,6 @@
 			"integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
 				"@typescript-eslint/scope-manager": "8.57.1",
@@ -4439,31 +4460,33 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
-			"integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
-				"@eslint-community/regexpp": "^4.12.2",
-				"@eslint/config-array": "^0.23.3",
-				"@eslint/config-helpers": "^0.5.2",
-				"@eslint/core": "^1.1.1",
-				"@eslint/plugin-kit": "^0.6.1",
+				"@eslint-community/regexpp": "^4.12.1",
+				"@eslint/config-array": "^0.21.2",
+				"@eslint/config-helpers": "^0.4.2",
+				"@eslint/core": "^0.17.0",
+				"@eslint/eslintrc": "^3.3.5",
+				"@eslint/js": "9.39.4",
+				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
 				"ajv": "^6.14.0",
+				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^9.1.2",
-				"eslint-visitor-keys": "^5.0.1",
-				"espree": "^11.1.1",
-				"esquery": "^1.7.0",
+				"eslint-scope": "^8.4.0",
+				"eslint-visitor-keys": "^4.2.1",
+				"espree": "^10.4.0",
+				"esquery": "^1.5.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^8.0.0",
@@ -4473,7 +4496,8 @@
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"minimatch": "^10.2.4",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.1.5",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -4481,7 +4505,7 @@
 				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://eslint.org/donate"
@@ -4968,19 +4992,17 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@types/esrecurse": "^4.3.1",
-				"@types/estree": "^1.0.8",
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -4999,45 +5021,126 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+		"node_modules/eslint/node_modules/@eslint/eslintrc": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
 			"dev": true,
-			"license": "Apache-2.0",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^6.14.0",
+				"debug": "^4.3.2",
+				"espree": "^10.0.1",
+				"globals": "^14.0.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.1",
+				"minimatch": "^3.1.5",
+				"strip-json-comments": "^3.1.1"
+			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/@eslint/js": {
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			}
+		},
+		"node_modules/eslint/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/eslint/node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/eslint/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/globals": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/espree": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.16.0",
+				"acorn": "^8.15.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^5.0.1"
+				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -6011,6 +6114,7 @@
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -9348,7 +9452,6 @@
 			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
 	},
 	"devDependencies": {
 		"@n8n/node-cli": "*",
-		"eslint": "9.39.4",
+		"eslint": "10.0.3",
 		"prettier": "3.8.1",
-		"release-it": "19.2.4",
+		"release-it": "^19.2.4",
 		"typescript": "5.9.3"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
 	},
 	"devDependencies": {
 		"@n8n/node-cli": "*",
-		"eslint": "10.0.3",
+		"eslint": "9.39.4",
 		"prettier": "3.8.1",
-		"release-it": "^19.2.4",
+		"release-it": "19.2.4",
 		"typescript": "5.9.3"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	"devDependencies": {
 		"@n8n/node-cli": "*",
 		"eslint": "9.39.4",
-		"prettier": "3.8.1",
+		"prettier": "3.8.3",
 		"release-it": "19.2.4",
 		"typescript": "5.9.3"
 	},


### PR DESCRIPTION
## Summary

- Bumps `prettier` from 3.8.1 → 3.8.3
- Updates `@n8n/node-cli` from 0.23.0 → 0.23.1 in the lockfile
- Refreshes lockfile with latest transitive dependency versions
- `eslint` remains pinned at 9.39.4 (intentional, was downgraded from 10.x)


Made with [Cursor](https://cursor.com)