### PR TITLE
ci: add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` so repos generated from this template inherit automated dependency updates out of the box.
- Covers `npm` (weekly) and `github-actions` (monthly), with minor/patch npm updates grouped to reduce PR noise.

Closes #121.

## Notes
- Template repos propagate the entire `.github/` directory to generated repos, so no additional wiring is needed on the consumer side.
- The existing CI workflow runs on `pull_request` with no actor filter, so Dependabot PRs will be lint + build checked automatically.

## Test plan
- [ ] Confirm YAML is accepted by GitHub (Insights → Dependency graph → Dependabot tab shows no parse errors once merged).
- [ ] Verify a subsequent Dependabot PR triggers the existing CI workflow.

Made with [Cursor](https://cursor.com)